### PR TITLE
Upgrade Cumulus to v9.7.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -61,7 +61,7 @@ jobs:
         run: bundle install
 
       - name: Deploy Cumulus
-        run: terraspace all plan
+        run: bundle exec terraspace all plan
 
   deploy-uat:
     if: github.event_name == 'push' && github.event.ref == 'refs/heads/main'

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ DOCKER_RUN = docker run \
 	--volume ${PWD}:$(WORKDIR) \
 	--volume ${HOME}/.aws:/root/.aws \
 	--volume ${HOME}/.ssh:/root/.ssh
-TERRASPACE = $(DOCKER_RUN) $(IMAGE) terraspace
+TERRASPACE = $(DOCKER_RUN) $(IMAGE) bundle exec terraspace
 
 .DEFAULT_GOAL := help
 .PHONY: \

--- a/app/stacks/cumulus/main.tf
+++ b/app/stacks/cumulus/main.tf
@@ -160,7 +160,6 @@ module "cumulus" {
 
   rds_security_group         = local.rds_security_group
   rds_user_access_secret_arn = local.rds_user_access_secret_arn
-  rds_connection_heartbeat   = true
 
   urs_url             = var.urs_url
   urs_client_id       = data.aws_ssm_parameter.urs_client_id.value

--- a/config/helpers/cumulus_version_helper.rb
+++ b/config/helpers/cumulus_version_helper.rb
@@ -1,5 +1,5 @@
 module Terraspace::Project::CumulusVersionHelper
   def cumulus_version
-    "v9.3.0"
+    "v9.7.0"
   end
 end


### PR DESCRIPTION
In addition to Cumulus version bump from 9.3.0 to 9.7.0, remove module variable that was recently eliminated from the `cumulus` module.