### PR TITLE
Auto-create AWS service-linked role for Elasticsearch

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,8 +1,3 @@
 {
-  "deepscan.enable": true,
-  "terraform-ls.rootModules": [
-    "cumulus-tf",
-    "data-persistence-tf",
-    "rds-cluster-tf"
-  ]
+  "deepscan.enable": true
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,18 +8,24 @@ RUN apt-get remove -y awscli \
   && /tmp/aws/install --bin-dir /usr/bin \
   && rm -rf /tmp/awscliv2.zip /tmp/aws/
 
+# Install AWS Session Manager Plugin
+RUN curl "https://s3.amazonaws.com/session-manager-downloads/plugin/latest/ubuntu_64bit/session-manager-plugin.deb" -o "/tmp/session-manager-plugin.deb" \
+  && dpkg -i /tmp/session-manager-plugin.deb \
+  && rm -f /tmp/session-manager-plugin.deb
+
+# Install various Ruby and Terraspace dependencies
 RUN apt-get update && apt-get install -y \
   bsdmainutils \
   g++ \
   gcc \
   graphviz \
-  make \
-  && curl "https://s3.amazonaws.com/session-manager-downloads/plugin/latest/ubuntu_64bit/session-manager-plugin.deb" -o "session-manager-plugin.deb" \
-  && dpkg -i session-manager-plugin.deb \
-  && rm -f session-manager-plugin.deb
+  make
 
 WORKDIR /work
-
 COPY .terraform-version Gemfile Gemfile.lock ./
-RUN bundle install
+
+# Use tfenv to install Terraform (using version specified in .terraform-version)
 RUN tfenv install
+
+# Install all of the Terraspace Ruby dependencies listed in Gemfile.lock
+RUN bundle install && bundle clean --force

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,6 @@
 source "https://rubygems.org"
 
-gem "terraspace", '~> 0.6.13'
+gem "aws-sdk-iam"
 gem "rspec-terraspace"
+gem "terraspace"
 gem "terraspace_plugin_aws"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,13 +10,16 @@ GEM
     addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
     aws-eventstream (1.2.0)
-    aws-partitions (1.513.0)
+    aws-partitions (1.516.0)
     aws-sdk-core (3.121.1)
       aws-eventstream (~> 1, >= 1.0.2)
       aws-partitions (~> 1, >= 1.239.0)
       aws-sigv4 (~> 1.1)
       jmespath (~> 1.0)
     aws-sdk-dynamodb (1.63.0)
+      aws-sdk-core (~> 3, >= 3.120.0)
+      aws-sigv4 (~> 1.1)
+    aws-sdk-iam (1.61.0)
       aws-sdk-core (~> 3, >= 3.120.0)
       aws-sigv4 (~> 1.1)
     aws-sdk-kms (1.49.0)
@@ -295,9 +298,10 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  aws-sdk-iam
   rspec-terraspace
-  terraspace (~> 0.6.13)
+  terraspace
   terraspace_plugin_aws
 
 BUNDLED WITH
-   2.1.4
+   2.2.26

--- a/app/stacks/data-persistence/config/hooks/terraform.rb
+++ b/app/stacks/data-persistence/config/hooks/terraform.rb
@@ -1,0 +1,33 @@
+require "aws-sdk-iam"
+
+#
+# Per the Cumulus deployment documentation:
+#
+#     Amazon Elasticsearch Service does not use a VPC Endpoint. To use ES within
+#     a VPC, before deploying run:
+#
+#         aws iam create-service-linked-role --aws-service-name es.amazonaws.com
+#
+#     This operation only needs to be done once per account, but it must be done
+#     for both NGAP and regular AWS environments.
+#
+# See https://nasa.github.io/cumulus/docs/v9.6.0/deployment/deployment-readme#vpc-subnets-and-security-group
+#
+# This hook simply check to see if this service linked role exists, and if not,
+# it creates it so that we don't have to remember to do this manually before
+# deploying the first Cumulus deployment to a given AWS account.
+#
+class EnsureElasticsearchServiceLinkedRoleExists
+  def call(runner)
+    client = Aws::IAM::Client.new
+
+    begin
+      client.get_role(role_name: "AWSServiceRoleForAmazonElasticsearchService")
+    rescue Aws::IAM::Errors::NoSuchEntity
+      puts "Creating AWS IAM service linked role for service 'es.amazonaws.com'"
+      client.create_service_linked_role(aws_service_name: "es.amazonaws.com")
+    end
+  end
+end
+
+before("apply", execute: EnsureElasticsearchServiceLinkedRoleExists)


### PR DESCRIPTION
This automatically creates an AWS service-linked role for Elasticsearch before `terraform apply` is used for the `data-persistence` module, if the role does not already exist.

This is a convenience so that we never have to remember to do this manually prior to the first Cumulus deployment to an AWS account.

Refer to https://nasa.github.io/cumulus/docs/v9.6.0/deployment/deployment-readme#vpc-subnets-and-security-group