### PR TITLE
Upgrade Cumulus to v9.9.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,10 +20,14 @@ jobs:
         run: |
           echo "Nothing to unit test yet"
 
+  #
   # Intended only for locally testing development deployment job via `act`,
   # using the following command:
   #
-  #     act --secret-file .env -j deploy-dev workflow_dispatch
+  #     act --secret-file .env-act -j deploy-dev workflow_dispatch
+  #
+  # where the file .env-act must have the following environment variables set:
+  # AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, and AWS_REGION.
   #
   deploy-dev:
     if: github.event_name == 'workflow_dispatch' && github.event.ref != 'refs/heads/main'
@@ -36,10 +40,20 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ secrets.AWS_REGION }}
 
       - name: Update packages list
         run: sudo apt-get update -y
+
+      - name: Install AWS CLI v2
+        run: |
+          curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "/tmp/awscliv2.zip"
+          unzip -q /tmp/awscliv2.zip -d /tmp
+          /tmp/aws/install --bin-dir /usr/bin
+          rm -rf /tmp/awscliv2.zip /tmp/aws/
+          aws --version
 
       - name: Install tfenv
         run: |
@@ -61,7 +75,15 @@ jobs:
         run: bundle install
 
       - name: Deploy Cumulus
-        run: bundle exec terraspace all plan
+        env:
+          # Required because bin/ensure-buckets-exist.sh uses AWS CLI
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION: ${{ secrets.AWS_REGION }}
+        run: |
+          unset AWS_PROFILE
+          bundle exec terraspace logs -f &
+          bundle exec terraspace all plan
 
   deploy-uat:
     if: github.event_name == 'push' && github.event.ref == 'refs/heads/main'
@@ -106,4 +128,6 @@ jobs:
         run: bundle install
 
       - name: Deploy Cumulus
-        run: bundle exec terraspace all up --yes
+        run: |
+          bundle exec terraspace logs -f &
+          bundle exec terraspace all up --yes

--- a/config/helpers/cumulus_version_helper.rb
+++ b/config/helpers/cumulus_version_helper.rb
@@ -1,5 +1,5 @@
 module Terraspace::Project::CumulusVersionHelper
   def cumulus_version
-    "v9.7.0"
+    "v9.9.0"
   end
 end

--- a/config/terraform/terraform.tf
+++ b/config/terraform/terraform.tf
@@ -1,6 +1,10 @@
 terraform {
   required_version = "0.13.6"
   required_providers {
+    archive = {
+      source  = "hashicorp/archive",
+      version = "~> 2.2.0"
+    }
     aws = {
       source  = "hashicorp/aws"
       version = ">= 3.14.1"


### PR DESCRIPTION
Bump Cumulus version to 9.9.0 to not only keep up with the latest release, but also to potentially resolve a problem where the status of a successfully ingested granule is not updated to "completed" (and instead remains "queued").

This is causing problems for the Metrics team.

Hopefully this resolves the problem (requires reingesting sample granules). If not, further investigation will be required.