### PR TITLE
Fix statuses for executions and granules

### DIFF
--- a/app/stacks/cumulus/templates/discover-granules-workflow.asl.json
+++ b/app/stacks/cumulus/templates/discover-granules-workflow.asl.json
@@ -136,6 +136,7 @@
           "ResultPath": "$.exception"
         }
       ],
+      "OutputPath": "$[0]",
       "End": true
     },
     "SkipWorkflow": {

--- a/app/stacks/cumulus/templates/ingest-and-publish-granule-workflow.asl.json
+++ b/app/stacks/cumulus/templates/ingest-and-publish-granule-workflow.asl.json
@@ -188,6 +188,7 @@
           "ResultPath": "$.exception"
         }
       ],
+      "OutputPath": "$[0]",
       "End": true
     },
     "Failed": {


### PR DESCRIPTION
The output from the DiscoverAndQueueGranules and IngestAndPublishGranule workflows were wrapped in an array due to the use of Parallel tasks. This was preventing Cumulus from updating the statuses of successful executions as well as the statuses of granules successfully ingested. Executions were left as "running" and granules were left as "queued." This fix "unwraps" the output from the Parallel tasks so that Cumulus receives the expected output format, and can update statuses to "completed."