### PR TITLE
Integrate Launchpad auth for CMR ingest

### DIFF
--- a/app/stacks/cumulus/bin/ensure-buckets-exist.sh
+++ b/app/stacks/cumulus/bin/ensure-buckets-exist.sh
@@ -28,11 +28,7 @@ for _bucket in "${_existing_buckets[@]}"; do
 done
 
 for _bucket in "${_required_buckets[@]}"; do
-  if [[ -n "${_bucket_map[${_bucket}]:-}" ]]; then
-    echo "Found bucket '${_bucket}'"
-  else
-    echo "Creating bucket '${_bucket}'..."
-
+  if [[ -z "${_bucket_map[${_bucket}]:-}" ]]; then
     if ! _output=$(aws s3api create-bucket --bucket "${_bucket}" \
       --region "${AWS_REGION}" \
       --create-bucket-configuration LocationConstraint="${AWS_REGION}" 2>&1); then

--- a/app/stacks/cumulus/main.tf
+++ b/app/stacks/cumulus/main.tf
@@ -278,7 +278,7 @@ module "cumulus" {
 
   cmr_client_id      = "<%= expansion('csdap-cumulus-:ENV-:ACCOUNT') %>"
   cmr_environment    = local.cmr_environment
-  cmr_oauth_provider = var.cmr_oauth_provider
+  cmr_oauth_provider = "launchpad"
   cmr_provider       = local.cmr_provider
   # Earthdata Login (EDL) credentials.  For DEVELOPMENT deployments, these should
   # be your own credentials for https://uat.urs.earthdata.nasa.gov/.  Otherwise,
@@ -287,9 +287,9 @@ module "cumulus" {
   cmr_username = data.aws_ssm_parameter.cmr_username.value
   cmr_password = data.aws_ssm_parameter.cmr_password.value
 
-  launchpad_api         = var.launchpad_api
-  launchpad_certificate = var.launchpad_certificate
-  launchpad_passphrase  = var.launchpad_passphrase
+  launchpad_api         = "https://api.launchpad.nasa.gov/icam/api/sm/v1"
+  launchpad_certificate = "launchpad.pfx"
+  launchpad_passphrase  = data.aws_ssm_parameter.launchpad_passphrase.value
 
   oauth_provider   = var.oauth_provider
   oauth_user_group = var.oauth_user_group

--- a/app/stacks/cumulus/ssm_parameters.rb
+++ b/app/stacks/cumulus/ssm_parameters.rb
@@ -14,6 +14,10 @@
 # and is used here as an SSM parameter description.
 #
 
+# ------------------------------------------------------------------------------
+# SHARED (used by all stacks within same AWS account)
+# ------------------------------------------------------------------------------
+
 data("aws_ssm_parameter", "csdap_host_url",
   "//": "CSDAP Cognito Host URL",
   name: "/shared/cumulus/csdap-host-url"
@@ -33,6 +37,15 @@ data("aws_ssm_parameter", "cmr_environment",
   "//": "CMR Environment (SIT, UAT, or OPS)",
   name: "/shared/cumulus/cmr-environment"
 )
+
+data("aws_ssm_parameter", "launchpad_passphrase",
+  "//": "Launchpad Passphrase",
+  name: "/shared/cumulus/launchpad-passphrase"
+)
+
+# ------------------------------------------------------------------------------
+# STACK-SPECIFIC (not shared across stacks)
+# ------------------------------------------------------------------------------
 
 data("aws_ssm_parameter", "cmr_username",
   "//": "Earthdata Login (EDL) Username",

--- a/app/stacks/cumulus/templates/ingest-and-publish-granule-workflow.asl.json
+++ b/app/stacks/cumulus/templates/ingest-and-publish-granule-workflow.asl.json
@@ -164,10 +164,11 @@
                     "TargetPath": "$.payload"
                   },
                   "task_config": {
-                    "bucket": "{$.meta.buckets.protected.name}",
+                    "bucket": "{$.meta.buckets.internal.name}",
                     "stack": "{$.meta.stack}",
                     "cmr": "{$.meta.cmr}",
-                    "launchpad": "{$.meta.launchpad}"
+                    "launchpad": "{$.meta.launchpad}",
+                    "etags": "{$.meta.file_etags}"
                   }
                 }
               },

--- a/app/stacks/cumulus/variables.tf
+++ b/app/stacks/cumulus/variables.tf
@@ -42,11 +42,6 @@ variable "archive_api_url" {
   default     = null
 }
 
-variable "cmr_oauth_provider" {
-  type    = string
-  default = "earthdata"
-}
-
 variable "cumulus_distribution_url" {
   type    = string
   default = null
@@ -120,21 +115,6 @@ variable "ems_username" {
 variable "key_name" {
   type    = string
   default = null
-}
-
-variable "launchpad_api" {
-  type    = string
-  default = "launchpadApi"
-}
-
-variable "launchpad_certificate" {
-  type    = string
-  default = "launchpad.pfx"
-}
-
-variable "launchpad_passphrase" {
-  type    = string
-  default = ""
 }
 
 variable "log_api_gateway_to_cloudwatch" {

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "@ava/typescript": "^2.0.0",
     "@cumulus/types": "^9.9.0",
     "@istanbuljs/nyc-config-typescript": "^1.0.1",
+    "@tsconfig/node14": "^1.0.1",
     "@types/aws-lambda": "^8.10.85",
     "@types/lodash": "^4.14.177",
     "@types/node": "^16.11.1",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   "dependencies": {
     "@cumulus/cmr-client": "9.9.0",
     "@cumulus/common": "9.9.0",
-    "@cumulus/cumulus-message-adapter-js": "^2.0.1",
+    "@cumulus/cumulus-message-adapter-js": "2.0.4",
     "@cumulus/post-to-cmr": "9.9.0",
     "dayjs": "^1.10.7",
     "fp-ts": "^2.11.5",

--- a/src/lib/cma.ts
+++ b/src/lib/cma.ts
@@ -1,12 +1,11 @@
 import * as CMA from '@cumulus/cumulus-message-adapter-js';
 import * as M from '@cumulus/types/message';
-import * as L from 'aws-lambda';
 
-import * as $L from './lambda';
+import * as L from './lambda';
 
 export type CMAEvent = CMA.CMAMessage | M.CumulusMessage | M.CumulusRemoteMessage;
 export type CMAResult = CMA.CumulusMessageWithAssignedPayload | M.CumulusRemoteMessage;
-export type CMAAsyncHandler = $L.AsyncHandler<CMAEvent, CMAResult>;
+export type CMAAsyncHandler = L.AsyncHandler<CMAEvent, CMAResult>;
 
 /**
  * Convenience function for wrapping a "vanilla" async AWS Lambda Function handler
@@ -56,6 +55,8 @@ export type CMAAsyncHandler = $L.AsyncHandler<CMAEvent, CMAResult>;
  *    handler for use with the Cumulus Message Adapter (CMA)
  */
 export const asyncHandler =
-  <E, R>(handler: $L.AsyncHandler<E, R>): CMAAsyncHandler =>
+  <E, R>(handler: L.AsyncHandler<E, R>) =>
   (event: CMAEvent, context: L.Context): Promise<CMAResult> =>
     CMA.runCumulusTask(handler, event, context);
+
+export * from '@cumulus/cumulus-message-adapter-js';

--- a/src/lib/discovery.ts
+++ b/src/lib/discovery.ts
@@ -1,6 +1,6 @@
 import { Duration } from 'dayjs/plugin/duration';
 import * as O from 'fp-ts/Option';
-import { constant } from 'fp-ts/function';
+import { constant, pipe } from 'fp-ts/function';
 import * as t from 'io-ts';
 import * as tt from 'io-ts-types';
 
@@ -60,9 +60,10 @@ export const formatProviderPath = (props: DiscoverGranulesProps) => {
  */
 export const advanceStartDate = (props: DiscoverGranulesProps) => {
   const { startDate, step } = props.config;
-  const endDate = O.getOrElse(() => new Date(Date.now()))(props.config.endDate);
+  const now = () => new Date(Date.now());
+  const endDate = pipe(props.config.endDate, O.getOrElse(now));
   const addDuration = (d: Duration) => dayjs.utc(startDate).add(d).toDate();
-  const nextStartDate = O.match(constant(endDate), addDuration)(step);
+  const nextStartDate = pipe(step, O.match(constant(endDate), addDuration));
 
   return nextStartDate < endDate ? nextStartDate.toISOString() : null;
 };

--- a/src/lib/discovery.ts
+++ b/src/lib/discovery.ts
@@ -7,7 +7,7 @@ import * as tt from 'io-ts-types';
 import * as CMA from './cma';
 import dayjs from './dayjs';
 import * as $t from './io';
-import * as $L from './lambda';
+import * as L from './lambda';
 import { traceAsync } from './logging';
 
 export const DiscoverGranulesProps = t.type({
@@ -71,7 +71,7 @@ export const advanceStartDate = (props: DiscoverGranulesProps) => {
 // HANDLERS
 //------------------------------------------------------------------------------
 
-const mkDiscoverGranulesHandler = $L.mkAsyncHandler(DiscoverGranulesProps);
+const mkDiscoverGranulesHandler = L.mkAsyncHandler(DiscoverGranulesProps);
 
 // For testing
 

--- a/src/lib/ingestion.ts
+++ b/src/lib/ingestion.ts
@@ -47,11 +47,12 @@ export const cmrValidate = async (props: IngestGranuleProps) => {
   // through.  We want to mock *only* the ingest (publish) request.  Further, since we
   // are mocking an empty response body, we should see a log message produced by
   // `postToCMR` that shows an undefined conceptId value.  If so, mocking succeeded.
+
   nock(cmrHost, { allowUnmocked: true })
     .put(/ingest/)
     .reply(200, {});
 
-  return postToCMR(props);
+  return await postToCMR(props);
 };
 
 // For testing

--- a/src/lib/lambda.spec.ts
+++ b/src/lib/lambda.spec.ts
@@ -1,11 +1,10 @@
 /* eslint-disable functional/no-return-void */
 import test from 'ava';
-import { Context } from 'aws-lambda';
 import * as tt from 'io-ts-types';
 
-import { mkAsyncHandler } from './lambda';
+import * as L from './lambda';
 
-const emptyContext: Context = Object.freeze({
+const emptyContext: L.Context = Object.freeze({
   callbackWaitsForEmptyEventLoop: false,
   functionName: '',
   functionVersion: '',
@@ -24,7 +23,7 @@ const emptyContext: Context = Object.freeze({
 });
 
 test('mkAsyncHandler should make an async handler', async (t) => {
-  const handler = mkAsyncHandler(tt.NumberFromString)((n: number) => n + 1);
+  const handler = L.mkAsyncHandler(tt.NumberFromString)((n: number) => n + 1);
   const actual = await handler('41', emptyContext);
 
   t.is(actual, 42);

--- a/src/lib/lambda.ts
+++ b/src/lib/lambda.ts
@@ -34,7 +34,7 @@ export const mkAsyncHandler =
   <C extends t.Any>(codec: C) =>
   <I extends t.TypeOf<C>, R>(h: PropsHandler<C, I, R>): AsyncHandler<unknown, R> =>
   async (event: unknown) =>
-    pipe(
+    await pipe(
       codec.decode(event),
       E.match(
         (errors) => Promise.reject(new Error(PR.failure(errors).join('\n'))),

--- a/src/lib/lambda.ts
+++ b/src/lib/lambda.ts
@@ -41,3 +41,5 @@ export const mkAsyncHandler =
         (decoded) => Promise.resolve(h(decoded))
       )
     );
+
+export { Context } from 'aws-lambda';

--- a/src/types/post-to-cmr.d.ts
+++ b/src/types/post-to-cmr.d.ts
@@ -3,5 +3,7 @@ declare module '@cumulus/post-to-cmr' {
     readonly granuleId: string;
   };
 
-  function postToCMR(event: unknown): readonly Granule[];
+  function postToCMR(
+    event: unknown
+  ): Promise<{ readonly granules: readonly Granule[] }>;
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,18 +1,14 @@
 {
+  "extends": "@tsconfig/node14/tsconfig.json",
   "compilerOptions": {
     "incremental": true,
-    "target": "es2020",
     "outDir": "build/main",
     "rootDir": "src",
     "moduleResolution": "node",
-    "module": "commonjs",
     "declaration": true,
     "inlineSourceMap": true,
-    "esModuleInterop": true /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */,
     "resolveJsonModule": true /* Include modules imported with .json extension. */,
-
     "strict": true /* Enable all strict type-checking options. */,
-
     /* Strict Type-Checking Options */
     // "noImplicitAny": true /* Raise error on expressions and declarations with an implied 'any' type. */,
     // "strictNullChecks": true /* Enable strict null checks. */,
@@ -20,28 +16,32 @@
     // "strictPropertyInitialization": true /* Enable strict checking of property initialization in classes. */,
     // "noImplicitThis": true /* Raise error on 'this' expressions with an implied 'any' type. */,
     // "alwaysStrict": true /* Parse in strict mode and emit "use strict" for each source file. */,
-
     /* Additional Checks */
     "noUnusedLocals": true /* Report errors on unused locals. */,
     "noUnusedParameters": true /* Report errors on unused parameters. */,
     "noImplicitReturns": true /* Report error when not all code paths in function return a value. */,
     "noFallthroughCasesInSwitch": true /* Report errors for fallthrough cases in switch statement. */,
-
     /* Debugging Options */
     "traceResolution": false /* Report module resolution log messages. */,
     "listEmittedFiles": false /* Print names of generated files part of the compilation. */,
     "listFiles": false /* Print names of files part of the compilation. */,
     "pretty": true /* Stylize errors and messages using color and context. */,
-
     /* Experimental Options */
     // "experimentalDecorators": true /* Enables experimental support for ES7 decorators. */,
     // "emitDecoratorMetadata": true /* Enables experimental support for emitting type metadata for decorators. */,
-
-    "lib": ["es2020"],
-    "types": ["node"],
-    "typeRoots": ["node_modules/@types", "src/types"]
+    "types": [
+      "node"
+    ],
+    "typeRoots": [
+      "node_modules/@types",
+      "src/types"
+    ]
   },
-  "include": ["src/**/*.ts"],
-  "exclude": ["node_modules/**"],
+  "include": [
+    "src/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules/**"
+  ],
   "compileOnSave": false
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -352,10 +352,10 @@
     execa "^4.0.0"
     lookpath "1.0.3"
 
-"@cumulus/cumulus-message-adapter-js@^2.0.1":
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/@cumulus/cumulus-message-adapter-js/-/cumulus-message-adapter-js-2.0.3.tgz#d101cebe648c80dc31165a3c0784d26d341b5af3"
-  integrity sha512-LtYotqf8XhhkMK1GDERTZQJtibwdjEEYH3Y34rMOUjjV5Um5zuFuMEZHmAeZFYeQ+MxGuWa9d0kbGuNUSKuElw==
+"@cumulus/cumulus-message-adapter-js@2.0.4":
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/@cumulus/cumulus-message-adapter-js/-/cumulus-message-adapter-js-2.0.4.tgz#e05b21e7dd5a1d9eff252934d390c67948247221"
+  integrity sha512-v89nPeF/K6AowShdS1YWHtDkSVWvUkytm52bMpb0PSacHeytI/eAuPV16BR/fdBCi6pFko5XHLGjrMrMqZFCOQ==
   dependencies:
     "@cumulus/types" "^9.6.0"
     "@types/aws-lambda" "^8.10.58"

--- a/yarn.lock
+++ b/yarn.lock
@@ -550,7 +550,7 @@
   resolved "https://registry.yarnpkg.com/@tsconfig/node12/-/node12-1.0.9.tgz#62c1f6dee2ebd9aead80dc3afa56810e58e1a04c"
   integrity sha512-/yBMcem+fbvhSREH+s14YJi18sp7J9jpuhYByADT2rypfajMZZN4WQ6zBGgBKp53NKmqI36wFYDb3yaMPurITw==
 
-"@tsconfig/node14@^1.0.0":
+"@tsconfig/node14@^1.0.0", "@tsconfig/node14@^1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@tsconfig/node14/-/node14-1.0.1.tgz#95f2d167ffb9b8d2068b0b235302fafd4df711f2"
   integrity sha512-509r2+yARFfHHE7T6Puu2jjkoycftovhXRqW328PDXTVGKihlb1P8Z9mMZH04ebyajfRY7dedfGynlrFHJUQCg==


### PR DESCRIPTION
Add configuration to use Launchpad instead of EDL for authentication during CMR ingest requests.

Includes a few other minor adjustments:

- Refactor prompt for AWS SSM Parameters to avoid double-prompting (once during "terraform plan" and again during "terraform apply")
- Bump cumulus-message-adapter-js to v2.0.4 to eliminate erroneous/confusing log messages
- Correct configuration of ValidateOrPublishMetadata step in IngestAndPublish workflow
- Slightly (arguably) improve some code readability
- Add missing `await`s in Lambda handlers