### PR TITLE
Move discover/queue granules steps to ECS tasks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,8 @@ DOCKER_RUN = docker run \
   --volume csdap-cumulus.node_modules:$(WORKDIR)/node_modules \
   --volume csdap-cumulus.node_modules.lambda:$(WORKDIR)/build/main/node_modules \
   --volume csdap-cumulus.node_modules.scripts:$(WORKDIR)/scripts/node_modules \
+  --volume csdap-cumulus.terraform-cache:$(WORKDIR)/.terraform \
+  --volume csdap-cumulus.terraspace-cache:$(WORKDIR)/.terraspace-cache \
   --volume $(PWD):$(WORKDIR) \
   --volume $(HOME)/.aws:/root/.aws \
   --volume $(HOME)/.ssh:/root/.ssh \

--- a/app/stacks/cumulus/templates/discover-granules-workflow.asl.json
+++ b/app/stacks/cumulus/templates/discover-granules-workflow.asl.json
@@ -78,7 +78,7 @@
                 }
               },
               "Type": "Task",
-              "Resource": "${discover_granules_task_arn}",
+              "Resource": "${discover_granules_activity_id}",
               "Retry": [
                 {
                   "ErrorEquals": [
@@ -123,6 +123,7 @@
                   },
                   "task_config": {
                     "queueUrl": "${background_job_queue_url}",
+                    "preferredQueueBatchSize": 5,
                     "provider": "{$.meta.provider}",
                     "internalBucket": "{$.meta.buckets.internal.name}",
                     "stackName": "{$.meta.stack}",
@@ -132,7 +133,7 @@
                 }
               },
               "Type": "Task",
-              "Resource": "${queue_granules_task_arn}",
+              "Resource": "${queue_granules_activity_id}",
               "Retry": [
                 {
                   "ErrorEquals": [

--- a/bin/create-test-data.sh
+++ b/bin/create-test-data.sh
@@ -46,7 +46,7 @@ echo "3. Follow the logs for discovery to confirm discovery of the uploaded"
 echo "   sample granule files (NOTE: it may take a minute or so before you see"
 echo "   any logging output):"
 echo
-echo "     aws logs tail --follow /aws/lambda/${CUMULUS_PREFIX}-DiscoverGranules"
+echo "     aws logs tail --follow ${CUMULUS_PREFIX}-DiscoverGranulesEcsLogs"
 echo
 echo "4. Follow the logs for ingestion to confirm CMR validation of the metadata"
 echo "   (NOTE: either kill the previous command with Ctrl-C, or open another"

--- a/scripts/src/cumulus.ts
+++ b/scripts/src/cumulus.ts
@@ -823,8 +823,10 @@ type RunnerOutput = {
 const isRunnerOutput = (u: unknown): u is RunnerOutput =>
   !fp.isNil(u) && fp.isObject(u) && fp.has('command', u) && fp.has('value', u);
 
-const leaf = (output: unknown): string =>
-  isRunnerOutput(output) ? leaf(output.value) : JSON.stringify(output, null, 2);
+const leaf = (output: unknown): string => {
+  if (isRunnerOutput(output)) return leaf(output.value);
+  return typeof output === 'string' ? output : JSON.stringify(output, null, 2);
+};
 
 const success = (message: string) => new Exit({ exitCode: 0, message, into: 'stdout' });
 
@@ -832,5 +834,5 @@ const failure = (message: string) => new Exit({ exitCode: 1, message, into: 'std
 
 Cmd.runSafely(app, process.argv)
   .then((result) => (Result.isErr(result) ? result.error : success(leaf(result.value))))
-  .catch(({ message }) => failure(message))
+  .catch(({ message }) => failure(`ERROR: ${message}`))
   .then((exit) => exit.run());


### PR DESCRIPTION
Moved discovery and queueing granules steps to ECS tasks.

The discovery and queuing steps of the DiscoverAndQueueGranules Step Function were not able to handle process of moderately-sized inputs without crashing or timing out, so they were moved to ECS tasks.
    
This helped, but even the default EC2 instance size (t3.medium) was still undersized, so bumping to t3.large and dialing up the CPU and memory reservation settings for the tasks finally did the trick.
    
Also, set preferredQueueBatchSize to 5 (from default of 1) to add some parallelization to the queuing step, without the need to increase the lambda function concurrency, which helped avoid some contention.

Some additional changes:

- Clarified Cumulus CLI output
   - Don't use JSON.stringify on strings
   - Prefix error messages with "ERROR" to make more explicit

- Attempted to speed up some Docker commands

Fixes #30