### PR TITLE
Remove UAT-specific prefix

### DIFF
--- a/app/stacks/cumulus/main.tf
+++ b/app/stacks/cumulus/main.tf
@@ -262,7 +262,7 @@ module "s3-replicator" {
   permissions_boundary = local.permissions_boundary_arn
   prefix               = var.prefix
   source_bucket        = var.system_bucket
-  source_prefix        = "${var.prefix}/ems-distribution/s3-server-access-logs/"
+  source_prefix        = "${var.prefix}/ems-distribution/s3-server-access-logs"
   subnet_ids           = module.vpc.subnets.ids
   target_bucket        = var.s3_replicator_target_bucket
   target_prefix        = var.s3_replicator_target_prefix

--- a/bin/create-test-data.sh
+++ b/bin/create-test-data.sh
@@ -12,16 +12,19 @@ echo -n "Looking up AWS Account ID ... "
 _account_id=$(aws sts get-caller-identity --query Account --output text)
 echo "Done"
 
-echo -n "Adding (or replacing) provider '${_provider}' ... "
-_provider_bucket=csdap-${CUMULUS_PREFIX}-provider-${_account_id}
+_bucket_prefix=$(test "${TS_ENV}" == "uat" && echo "csdap-uat-" || echo "csdap-${CUMULUS_PREFIX}-")
+_bucket_suffix=$(test "${TS_ENV}" == "uat" && echo "" || echo "-${_account_id}")
+
+echo -n "Upserting provider '${_provider}' ... "
+_provider_bucket=${_bucket_prefix}provider${_bucket_suffix}
 ./cumulus providers upsert --data '{ "id": "'"${_provider}"'", "protocol": "s3", "host": "'"${_provider_bucket}"'" }' >/dev/null
 echo "Done"
 
-echo -n "Adding (or replacing) collection '${_collection_id}' ... "
+echo -n "Upserting collection '${_collection_id}' ... "
 ./cumulus collections upsert --data "app/stacks/cumulus/resources/collections/${_collection_id}.json" >/dev/null
 echo "Done"
 
-echo -n "Adding (or replacing) rule '${_rule}' ... "
+echo -n "Upserting rule '${_rule}' ... "
 ./cumulus rules upsert --data "app/stacks/cumulus/resources/rules/${_rule}.json" >/dev/null
 echo "Done"
 

--- a/config/terraform/tfvars/uat.tfvars
+++ b/config/terraform/tfvars/uat.tfvars
@@ -1,4 +1,0 @@
-# UAT was deployed before the 'cumulus-:ENV' convention was in place (see
-# base.tfvars), so this preserves the original prefix for UAT to avoid having to
-# destroy and recreate the deployment.
-prefix = "csdap-uat"

--- a/scripts/src/cumulus.ts
+++ b/scripts/src/cumulus.ts
@@ -196,6 +196,12 @@ function mkApp(client: Client) {
         granules: granulesCmd(client),
         providers: providersCmd(client),
         rules: rulesCmd(client),
+        version: Cmd.command({
+          name: 'version',
+          description: 'Get the Cumulus API version',
+          args: globalArgs,
+          handler: ({ prefix }) => client.get(`/version`)({ prefix }),
+        }),
       },
     })
   );
@@ -1151,7 +1157,7 @@ function request({
         [fp.isError, (error) => Promise.reject(error)],
         [
           fp.overEvery([fp.prop('error'), fp.prop('message')]),
-          ({ message }) => Promise.reject(new Error(message)),
+          (body) => Promise.reject(Object.assign(new Error(), body)),
         ],
         [fp.stubTrue, fp.identity],
       ])


### PR DESCRIPTION
In an attempt to correct the problems we're having recreating
subscriptions between our SNS topics and the Cloud Metrics SQS queues,
we're recreating the UAT stack with a different prefix. Specifically,
we're dropping the UAT-specific prefix and defaulting to the pattern
used by all other stacks (i.e., `cumulus-${TS_ENV}`).