### PR TITLE
Upgrade CMA to 2.0.2

### DIFF
--- a/app/modules/cma/main.tf
+++ b/app/modules/cma/main.tf
@@ -7,6 +7,7 @@ locals {
 resource "null_resource" "download_cma_zip_file" {
   triggers = {
     bucket = var.bucket
+    version = var.cma_version
   }
 
   provisioner "local-exec" {

--- a/app/stacks/cumulus/main.tf
+++ b/app/stacks/cumulus/main.tf
@@ -253,7 +253,7 @@ module "cma" {
 
   prefix      = var.prefix
   bucket      = var.system_bucket
-  cma_version = "1.3.0"
+  cma_version = "2.0.2"
 }
 
 module "s3-replicator" {


### PR DESCRIPTION
After encountering an "out of memory" error related to the CMA in PostToCmr, the Cumulus team recommended upgrading the CMA layer, if for no other reason than because the later version provides more detailed log messages that can aid debugging.

This appears to perhaps addressed the memory issue.