### PR TITLE
Add custom bucket mapping to decouple bucket names

### DIFF
--- a/app/stacks/cumulus/main.tf
+++ b/app/stacks/cumulus/main.tf
@@ -3,8 +3,10 @@ locals {
   public_bucket_names    = [for k, v in var.buckets : v.name if v.type == "public"]
 
   bucket_map_yaml = templatefile("${path.module}/templates/bucket_map.yaml.tmpl", {
-    protected_buckets = local.protected_bucket_names,
-    public_buckets    = local.public_bucket_names,
+    # This assumes only 1 protected and 1 public bucket
+    protected_bucket = local.protected_bucket_names[0],
+    public_bucket    = local.public_bucket_names[0],
+    base             = "<%= expansion('csdap-cumulus-:ENV') %>",
   })
 
   cmr_environment = data.aws_ssm_parameter.cmr_environment.value

--- a/app/stacks/cumulus/templates/bucket_map.yaml.tmpl
+++ b/app/stacks/cumulus/templates/bucket_map.yaml.tmpl
@@ -1,19 +1,5 @@
-%{ if (length(public_buckets) + length(protected_buckets)) > 0 ~}
 MAP:
-%{ if length(public_buckets) > 0 ~}
-%{ for bucket in distinct(protected_buckets) ~}
-  ${bucket}: ${bucket}
-%{ endfor ~}
-%{ endif ~}
-%{ if length(public_buckets) > 0 ~}
-%{ for bucket in distinct(public_buckets) ~}
-  ${bucket}: ${bucket}
-%{ endfor ~}
-%{ endif ~}
-%{ endif ~}
-%{ if length(public_buckets) > 0 ~}
+  ${base}-protected: ${protected_bucket}
+  ${base}-public: ${public_bucket}
 PUBLIC_BUCKETS:
-%{ for bucket in distinct(public_buckets) ~}
-  - ${bucket}
-%{ endfor ~}
-%{ endif ~}
+  - ${public_bucket}


### PR DESCRIPTION
Create custom bucket map to decouple bucket names from distribution URLs for downloading granules files. This does at least 2 things:

1. Avoids exposing AWS account IDs where bucket names include Account IDs
2. Allows us to use different buckets without having to modify download URLs in published metadata (we would need only to update the bucket mapping [and redeploy] to allow distribution to continue working)