### PR TITLE
Remove AWS account ID from bucket names

### DIFF
--- a/app/stacks/cumulus/main.tf
+++ b/app/stacks/cumulus/main.tf
@@ -433,7 +433,7 @@ module "cumulus" {
   metrics_es_username = data.aws_ssm_parameter.metrics_es_username.value
   metrics_es_password = data.aws_ssm_parameter.metrics_es_password.value
 
-  cmr_client_id      = "<%= expansion('csdap-cumulus-:ENV-:ACCOUNT') %>"
+  cmr_client_id      = "<%= expansion('csdap-cumulus-:ENV') %>"
   cmr_environment    = local.cmr_environment
   cmr_oauth_provider = "launchpad"
   cmr_provider       = local.cmr_provider

--- a/app/stacks/cumulus/tfvars/base.tfvars
+++ b/app/stacks/cumulus/tfvars/base.tfvars
@@ -13,31 +13,31 @@
 #<% depends_on("data-persistence") %>
 #<% depends_on("rds-cluster") %>
 
-system_bucket = "<%= expansion('csdap-cumulus-:ENV-internal-:ACCOUNT') %>"
+system_bucket = "<%= expansion('csdap-cumulus-:ENV-internal') %>"
 
 buckets = {
   internal = {
-    name = "<%= expansion('csdap-cumulus-:ENV-internal-:ACCOUNT') %>"
+    name = "<%= expansion('csdap-cumulus-:ENV-internal') %>"
     type = "internal"
   }
   private = {
-    name = "<%= expansion('csdap-cumulus-:ENV-private-:ACCOUNT') %>"
+    name = "<%= expansion('csdap-cumulus-:ENV-private') %>"
     type = "private"
   }
   protected = {
-    name = "<%= expansion('csdap-cumulus-:ENV-protected-:ACCOUNT') %>"
+    name = "<%= expansion('csdap-cumulus-:ENV-protected') %>"
     type = "protected"
   }
   public = {
-    name = "<%= expansion('csdap-cumulus-:ENV-public-:ACCOUNT') %>"
+    name = "<%= expansion('csdap-cumulus-:ENV-public') %>"
     type = "public"
   }
   dashboard = {
-    name = "<%= expansion('csdap-cumulus-:ENV-dashboard-:ACCOUNT') %>"
+    name = "<%= expansion('csdap-cumulus-:ENV-dashboard') %>"
     type = "dashboard"
   }
   provider = {
-    name = "<%= expansion('csdap-cumulus-:ENV-provider-:ACCOUNT') %>"
+    name = "<%= expansion('csdap-cumulus-:ENV-provider') %>"
     type = "provider"
   }
 }

--- a/app/stacks/cumulus/tfvars/prod.tfvars
+++ b/app/stacks/cumulus/tfvars/prod.tfvars
@@ -1,8 +1,3 @@
-api_users = [
-  "dschuck",
-  "kaulfus08"
-]
-
 # Trailing slash is required
 cumulus_distribution_url    = "https://dy8riyaot0kde.cloudfront.net/"
 s3_replicator_target_bucket = "esdis-metrics-inbound-prod-csdap-distribution"
@@ -10,23 +5,23 @@ s3_replicator_target_prefix = "input/s3_access/csdapprod"
 
 buckets = {
   internal = {
-    name = "<%= expansion('csdap-cumulus-:ENV-internal-:ACCOUNT') %>"
+    name = "<%= expansion('csdap-cumulus-:ENV-internal') %>"
     type = "internal"
   }
   private = {
-    name = "<%= expansion('csdap-cumulus-:ENV-private-:ACCOUNT') %>"
+    name = "<%= expansion('csdap-cumulus-:ENV-private') %>"
     type = "private"
   }
   protected = {
-    name = "<%= expansion('csdap-cumulus-:ENV-protected-:ACCOUNT') %>"
+    name = "<%= expansion('csdap-cumulus-:ENV-protected') %>"
     type = "protected"
   }
   public = {
-    name = "<%= expansion('csdap-cumulus-:ENV-public-:ACCOUNT') %>"
+    name = "<%= expansion('csdap-cumulus-:ENV-public') %>"
     type = "public"
   }
   dashboard = {
-    name = "<%= expansion('csdap-cumulus-:ENV-dashboard-:ACCOUNT') %>"
+    name = "<%= expansion('csdap-cumulus-:ENV-dashboard') %>"
     type = "dashboard"
   }
   provider = {

--- a/bin/create-test-data.sh
+++ b/bin/create-test-data.sh
@@ -8,15 +8,10 @@ _collection_version="1"
 _collection_id="${_collection_name}___${_collection_version}"
 _rule="${_collection_id}_SmokeTest"
 
-echo -n "Looking up AWS Account ID ... "
-_account_id=$(aws sts get-caller-identity --query Account --output text)
-echo "Done"
-
 _bucket_prefix=$(test "${TS_ENV}" == "uat" && echo "csdap-uat-" || echo "csdap-${CUMULUS_PREFIX}-")
-_bucket_suffix=$(test "${TS_ENV}" == "uat" && echo "" || echo "-${_account_id}")
 
 echo -n "Upserting provider '${_provider}' ... "
-_provider_bucket=${_bucket_prefix}provider${_bucket_suffix}
+_provider_bucket=${_bucket_prefix}provider
 ./cumulus providers upsert --data '{ "id": "'"${_provider}"'", "protocol": "s3", "host": "'"${_provider_bucket}"'" }' >/dev/null
 echo "Done"
 

--- a/config/args/terraform.rb
+++ b/config/args/terraform.rb
@@ -1,0 +1,5 @@
+# See https://terraspace.cloud/docs/config/args/terraform/
+
+command("init",
+  args: ["-reconfigure"],
+)

--- a/config/terraform/backend.tf
+++ b/config/terraform/backend.tf
@@ -1,7 +1,7 @@
 terraform {
   backend "s3" {
     region         = "<%= expansion(':REGION') %>"
-    bucket         = "<%= expansion('csdap-cumulus-:ENV-tfstate-:ACCOUNT') %>"
+    bucket         = "<%= expansion('csdap-cumulus-:ENV-tfstate') %>"
     key            = "<%= expansion(':ENV/:MOD_NAME/terraform.tfstate') %>"
     encrypt        = true
     dynamodb_table = "<%= expansion('cumulus-:ENV-tfstate-locks') %>"


### PR DESCRIPTION
Fixes #50 by removing AWS account ID from all buckets.