### PR TITLE
Fix deployment errors due to NGAP and AWS changes

### DIFF
--- a/app/modules/vpc/main.tf
+++ b/app/modules/vpc/main.tf
@@ -4,11 +4,9 @@ data "aws_vpc" "ngap_vpc" {
   }
 }
 
-data "aws_subnet_ids" "ngap_subnets" {
-  vpc_id = data.aws_vpc.ngap_vpc.id
-
+data "aws_subnets" "ngap_subnets" {
   filter {
     name   = "tag:Name"
-    values = ["Private application *"]
+    values = ["Private application *a subnet", "Private application *b subnet"]
   }
 }

--- a/app/modules/vpc/outputs.tf
+++ b/app/modules/vpc/outputs.tf
@@ -3,5 +3,5 @@ output "vpc_id" {
 }
 
 output "subnets" {
-  value = data.aws_subnet_ids.ngap_subnets
+  value = data.aws_subnets.ngap_subnets
 }

--- a/app/stacks/rds-cluster/variables.tf
+++ b/app/stacks/rds-cluster/variables.tf
@@ -13,7 +13,7 @@ variable "deletion_protection" {
 variable "engine_version" {
   description = "Postgres engine version for Serverless cluster"
   type        = string
-  default     = "10.14"
+  default     = "10.18"
 }
 
 variable "provision_user_database" {


### PR DESCRIPTION
NGAP added a 3rd subnet, which broke the data-persistence module
deployment, which expects exactly 2 subnets. This setting is not exposed
by Cumulus, so it was necessary to adjust the filter that selects the
appropriate subnets such that exactly 2 subnets are selected.

Additionally, replace deprecated Terraform `aws_subnet_ids` data source
with recommended `aws_subnets` data source, per documentation.

AWS auto-upgraded RDS Serverless from version 10.14 to 10.18, which broke
the rds-cluster deployment. Changing the `engine_version` variable to
`"10.18"` addresses this.

Fix #52