### PR TITLE
Fix PostToCmr ENOMEM error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,12 +11,12 @@ RUN : \
   && apt-get update -y \
   && apt-get install -y --no-install-recommends \
   # Ruby requires the following to build gem native extensions
-  g++=4:9.3.0-1ubuntu2 \
-  make=4.2.1-1.2 \
+  g++=4:11.2.0-1ubuntu1 \
+  make=4.3-4.1build1 \
   # AWS CLI help system requires groff
-  groff=1.22.4-4build1 \
+  groff=1.22.4-8build1 \
   # AWS Support Tools Lambda FindEniMappings requires jq
-  jq=1.6-1ubuntu0.20.04.1 \
+  jq=1.6-2.1ubuntu3 \
   && apt-get autoremove -y \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/* \
@@ -59,6 +59,7 @@ RUN tfenv install
 # Install nvm, node (version specified in `.nvmrc`), npm, and yarn
 ENV NVM_DIR=/usr/local/nvm
 COPY .nvmrc ./
+# hadolint ignore=SC1091
 RUN : \
   && mkdir -p "${NVM_DIR}" \
   && curl --no-progress-meter -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.0/install.sh | bash \

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 source "https://rubygems.org"
 
 gem "aws-sdk-iam"
+gem "aws-sdk-lambda"
 gem "rspec-terraspace"
 gem "terraspace"
 gem "terraspace_plugin_aws"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,38 +1,41 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (7.0.2.3)
+    activesupport (7.0.3)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
       tzinfo (~> 2.0)
     aws-eventstream (1.2.0)
-    aws-partitions (1.566.0)
-    aws-sdk-core (3.130.0)
+    aws-partitions (1.601.0)
+    aws-sdk-core (3.131.2)
       aws-eventstream (~> 1, >= 1.0.2)
       aws-partitions (~> 1, >= 1.525.0)
       aws-sigv4 (~> 1.1)
-      jmespath (~> 1.0)
-    aws-sdk-dynamodb (1.74.0)
+      jmespath (~> 1, >= 1.6.1)
+    aws-sdk-dynamodb (1.75.0)
       aws-sdk-core (~> 3, >= 3.127.0)
       aws-sigv4 (~> 1.1)
-    aws-sdk-iam (1.68.0)
+    aws-sdk-iam (1.69.0)
       aws-sdk-core (~> 3, >= 3.127.0)
       aws-sigv4 (~> 1.1)
-    aws-sdk-kms (1.55.0)
+    aws-sdk-kms (1.57.0)
       aws-sdk-core (~> 3, >= 3.127.0)
       aws-sigv4 (~> 1.1)
-    aws-sdk-s3 (1.113.0)
+    aws-sdk-lambda (1.84.0)
+      aws-sdk-core (~> 3, >= 3.127.0)
+      aws-sigv4 (~> 1.1)
+    aws-sdk-s3 (1.114.0)
       aws-sdk-core (~> 3, >= 3.127.0)
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.4)
-    aws-sdk-secretsmanager (1.59.0)
+    aws-sdk-secretsmanager (1.64.0)
       aws-sdk-core (~> 3, >= 3.127.0)
       aws-sigv4 (~> 1.1)
-    aws-sdk-ssm (1.132.0)
+    aws-sdk-ssm (1.137.0)
       aws-sdk-core (~> 3, >= 3.127.0)
       aws-sigv4 (~> 1.1)
-    aws-sigv4 (1.4.0)
+    aws-sigv4 (1.5.0)
       aws-eventstream (~> 1, >= 1.0.2)
     aws_data (0.1.1)
       aws-sdk-core
@@ -41,11 +44,11 @@ GEM
       activesupport
       text-table
       zeitwerk
-    concurrent-ruby (1.1.9)
+    concurrent-ruby (1.1.10)
     deep_merge (1.2.2)
     diff-lcs (1.5.0)
     dotenv (2.7.6)
-    dsl_evaluator (0.2.5)
+    dsl_evaluator (0.3.0)
       activesupport
       memoist
       rainbow
@@ -61,8 +64,8 @@ GEM
     jmespath (1.6.1)
     memoist (0.16.2)
     mini_portile2 (2.8.0)
-    minitest (5.15.0)
-    nokogiri (1.13.3)
+    minitest (5.16.1)
+    nokogiri (1.13.6)
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
     racc (1.6.0)
@@ -83,7 +86,7 @@ GEM
     rspec-expectations (3.11.0)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.11.0)
-    rspec-mocks (3.11.0)
+    rspec-mocks (3.11.1)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.11.0)
     rspec-support (3.11.0)
@@ -104,7 +107,7 @@ GEM
       text-table
       thor
       zeitwerk
-    terraspace (1.1.7)
+    terraspace (2.0.2)
       activesupport
       bundler
       cli-format
@@ -123,6 +126,7 @@ GEM
       thor
       tty-tree
       zeitwerk
+      zip_folder
     terraspace-bundler (0.5.0)
       activesupport
       aws-sdk-s3
@@ -133,7 +137,7 @@ GEM
       rubyzip
       thor
       zeitwerk
-    terraspace_plugin_aws (0.3.7)
+    terraspace_plugin_aws (0.4.1)
       aws-sdk-dynamodb
       aws-sdk-s3
       aws-sdk-secretsmanager
@@ -148,13 +152,16 @@ GEM
     tty-tree (0.4.0)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
-    zeitwerk (2.5.4)
+    zeitwerk (2.6.0)
+    zip_folder (0.1.0)
+      rubyzip
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   aws-sdk-iam
+  aws-sdk-lambda
   rspec-terraspace
   terraspace
   terraspace_plugin_aws

--- a/app/stacks/cumulus/main.tf
+++ b/app/stacks/cumulus/main.tf
@@ -133,7 +133,7 @@ resource "aws_cloudwatch_event_target" "background_job_queue_watcher" {
   arn  = module.cumulus.sqs2sfThrottle_lambda_function_arn
   input = jsonencode(
     {
-      messageLimit = 500
+      messageLimit = 250
       queueUrl     = aws_sqs_queue.background_job_queue.id
       timeLimit    = 60
     }
@@ -491,7 +491,7 @@ module "cumulus" {
     {
       id              = "backgroundJobQueue",
       url             = aws_sqs_queue.background_job_queue.id,
-      execution_limit = 250
+      execution_limit = 125
     }
   ]
 }


### PR DESCRIPTION
Fixes the ENOMEM errors encountered in `PostToCmr`.

Also, dials down concurrency by half to avoid exceeding S3 rate limit
during `SyncGranule` (which was exposed in the course of testing the fix
for the memory error in `PostToCmr`).

Additionally, updated Dockerfile to install correct library versions, as running
`make docker` was failing due to failures to find some libraries.

Fixes #55