### PR TITLE
Increase size of Elasticsearch cluster in prod

### DIFF
--- a/app/stacks/data-persistence/tfvars/prod.tfvars
+++ b/app/stacks/data-persistence/tfvars/prod.tfvars
@@ -1,0 +1,20 @@
+# Although main.tf uses the Terraspace `output` helper function to obtain
+# outputs from the rds-cluster module, the dependency on that module is
+# not recognized by Terraspace unless the `output` or `depends_on` helper
+# function is used in a tfvars file.
+#
+# While we could use the `output` helper function in this file, that would
+# require defining new variables, so we simply use `depends_on` instead.
+#
+# NOTE: The following line is commented out only to avoid Terraform syntax
+# warnings in editors that recognize Terraform files.  Although it is commented
+# out, Terraspace still recognizes the dependency.
+#<% depends_on("rds-cluster") %>
+
+elasticsearch_config = {
+  domain_name    = "es"
+  instance_count = 3
+  instance_type  = "r5.large.elasticsearch"
+  version        = "5.3"
+  volume_size    = 500
+}


### PR DESCRIPTION
This should be much closer to a proper configuration to handle Elasticsearch needs in production, but is very much a mildly educated guess.

Issue #62