### PR TITLE
Use an even number of data nodes for ES cluster

### DIFF
--- a/app/stacks/data-persistence/tfvars/prod.tfvars
+++ b/app/stacks/data-persistence/tfvars/prod.tfvars
@@ -13,7 +13,7 @@
 
 elasticsearch_config = {
   domain_name    = "es"
-  instance_count = 3
+  instance_count = 4
   instance_type  = "r5.large.elasticsearch"
   version        = "5.3"
   volume_size    = 500


### PR DESCRIPTION
Deployment to prod failed due to the following error:

```
Error: ValidationException: You must choose an even number of data nodes for a two Availability Zone deployment

  on .terraform/modules/data_persistence/tf-modules/data-persistence/elasticsearch.tf line 84, in resource "aws_elasticsearch_domain" "es_vpc":
  84: resource "aws_elasticsearch_domain" "es_vpc" {
```

Issue #62