### PR TITLE
Make ingest/pub fail when missing CMR file

### DIFF
--- a/app/stacks/cumulus/resources/rules/WV04_MSI_L1B___1_SmokeTest.json
+++ b/app/stacks/cumulus/resources/rules/WV04_MSI_L1B___1_SmokeTest.json
@@ -12,12 +12,12 @@
   "workflow": "DiscoverAndQueueGranules",
   "meta": {
     "discoverOnly": false,
-    "providerPathFormat": "'css/nga/WV04/1B/'yyyy",
+    "providerPathFormat": "'css/nga/WV04/1B/'yyyy/DDD",
     "rule": {
       "state": "DISABLED"
     },
-    "startDate": "2017-01-01",
-    "endDate": "2019-01-01",
-    "step": "P1Y"
+    "startDate": "2017-05-05",
+    "endDate": "2017-05-06",
+    "step": "P1D"
   }
 }

--- a/app/stacks/cumulus/templates/ingest-and-publish-granule-workflow.asl.json
+++ b/app/stacks/cumulus/templates/ingest-and-publish-granule-workflow.asl.json
@@ -6,8 +6,38 @@
       "Branches": [
         {
           "Comment": "Ingest Granule",
-          "StartAt": "SyncGranule",
+          "StartAt": "RequireCmrFiles",
           "States": {
+            "RequireCmrFiles": {
+              "Type": "Task",
+              "Resource": "${require_cmr_files_task_arn}",
+              "Parameters": {
+                "cma": {
+                  "event.$": "$",
+                  "ReplaceConfig": {
+                    "MaxSize": 16384,
+                    "Path": "$.payload",
+                    "TargetPath": "$.payload"
+                  },
+                  "task_config": {
+                    "cumulus_message": {
+                      "input": "{$.payload}",
+                      "outputs": [
+                        {
+                          "source": "{$.granules}",
+                          "destination": "{$.meta.input_granules}"
+                        },
+                        {
+                          "source": "{$}",
+                          "destination": "{$.payload}"
+                        }
+                      ]
+                    }
+                  }
+                }
+              },
+              "Next": "SyncGranule"
+            },
             "SyncGranule": {
               "Parameters": {
                 "cma": {

--- a/src/lib/ingestion.spec.ts
+++ b/src/lib/ingestion.spec.ts
@@ -3,7 +3,62 @@ import * as RTE from 'fp-ts/ReaderTaskEither';
 import { pipe } from 'fp-ts/function';
 
 import { getObject } from './aws/s3.fixture';
-import { addUmmgChecksumsHandlerRT, readUmmgRTE } from './ingestion';
+import {
+  addUmmgChecksumsHandlerRT,
+  readUmmgRTE,
+  requireCmrFilesHandler,
+} from './ingestion';
+
+//------------------------------------------------------------------------------
+// requireCmrFilesHandler
+//------------------------------------------------------------------------------
+
+test('requireCmrFilesHandler should resolve to original event when granules list is empty', async (t) => {
+  const event = { input: { granules: [] } };
+
+  t.is(await requireCmrFilesHandler(event), event);
+});
+
+test('requireCmrFilesHandler should resolve to original event when every granule includes a CMR file', async (t) => {
+  const event = {
+    input: {
+      granules: [
+        {
+          files: [{ name: 'data.tif' }, { name: 'cmr.json' }],
+        },
+      ],
+    },
+  };
+
+  t.is(await requireCmrFilesHandler(event), event);
+});
+
+test('requireCmrFilesHandler should reject when a single granule does not include a CMR file', async (t) => {
+  const event = { input: { granules: [{ files: [] }] } };
+
+  await t.throwsAsync(requireCmrFilesHandler(event), {
+    message: (message) => message.endsWith(JSON.stringify(event.input.granules)),
+  });
+});
+
+test('requireCmrFilesHandler should reject when multiple granules do not include a CMR file', async (t) => {
+  const granulesMissingCmrFile = [
+    { files: [{ name: 'data2.tif' }] },
+    { files: [{ name: 'data3.tif' }] },
+  ];
+  const event = {
+    input: {
+      granules: [
+        { files: [{ name: 'data1.tif' }, { name: 'cmr.json' }] },
+        ...granulesMissingCmrFile,
+      ],
+    },
+  };
+
+  await t.throwsAsync(requireCmrFilesHandler(event), {
+    message: (message) => message.endsWith(JSON.stringify(granulesMissingCmrFile)),
+  });
+});
 
 //------------------------------------------------------------------------------
 // addUmmgChecksumsHandlerRT
@@ -88,7 +143,7 @@ test('addUmmgChecksumsHandlerRT should add checksums from cmr.json', async (t) =
 
 test(`readUmmgRTE should return Right(UMM.G) upon success`, async (t) => {
   const program = pipe(
-    readUmmgRTE({ bucket: 'my-bucket', key: 'cmr.json' }),
+    readUmmgRTE({ bucket: 'my-bucket', key: 'cmr.json', fileName: 'cmr.json' }),
     RTE.match(
       (e) => t.fail(String(e)),
       () => t.pass()
@@ -100,7 +155,7 @@ test(`readUmmgRTE should return Right(UMM.G) upon success`, async (t) => {
 
 test(`readUmmgRTE should return Left(Error) for S3 failure`, async (t) => {
   const program = pipe(
-    readUmmgRTE({ bucket: 'no-such-bucket', key: 'cmr.json' }),
+    readUmmgRTE({ bucket: 'no-such-bucket', key: 'cmr.json', fileName: 'cmr.json' }),
     RTE.match(
       (e) => t.regex(e.message, /no-such-bucket/),
       () => t.fail('expected "no such bucket" error')
@@ -112,7 +167,7 @@ test(`readUmmgRTE should return Left(Error) for S3 failure`, async (t) => {
 
 test(`readUmmgRTE should return Left(Error) for decoding failure`, async (t) => {
   const program = pipe(
-    readUmmgRTE({ bucket: 'my-bucket', key: 'empty.json' }),
+    readUmmgRTE({ bucket: 'my-bucket', key: 'empty.json', fileName: 'empty.json' }),
     RTE.match(
       (e) => t.regex(e.message, /invalid value/i),
       () => t.fail('expected decoding error')


### PR DESCRIPTION
Before incurring the expense of synching granule files, first make sure each granule has a CMR metadata file. If not, fail the workflow _before_ synching since it will eventually fail on the PostToCmr step. This way, we avoid the unnecessary egress costs.