### PR TITLE
Fix output from RequireCmrFile step

### DIFF
--- a/app/stacks/cumulus/resources/rules/WV04_MSI_L1B___1_SmokeTest.json
+++ b/app/stacks/cumulus/resources/rules/WV04_MSI_L1B___1_SmokeTest.json
@@ -1,5 +1,5 @@
 {
-  "name": "WV04_MSI_L1B___1",
+  "name": "WV04_MSI_L1B___1_SmokeTest",
   "state": "DISABLED",
   "rule": {
     "type": "onetime"

--- a/src/lib/ingestion.spec.ts
+++ b/src/lib/ingestion.spec.ts
@@ -16,7 +16,7 @@ import {
 test('requireCmrFilesHandler should resolve to original event when granules list is empty', async (t) => {
   const event = { input: { granules: [] } };
 
-  t.is(await requireCmrFilesHandler(event), event);
+  t.is(await requireCmrFilesHandler(event), event.input);
 });
 
 test('requireCmrFilesHandler should resolve to original event when every granule includes a CMR file', async (t) => {
@@ -30,7 +30,7 @@ test('requireCmrFilesHandler should resolve to original event when every granule
     },
   };
 
-  t.is(await requireCmrFilesHandler(event), event);
+  t.is(await requireCmrFilesHandler(event), event.input);
 });
 
 test('requireCmrFilesHandler should reject when a single granule does not include a CMR file', async (t) => {

--- a/src/lib/ingestion.ts
+++ b/src/lib/ingestion.ts
@@ -208,7 +208,7 @@ export const requireCmrFilesHandler = (event: PreSyncEvent) =>
     ),
     E.match(
       (message) => Promise.reject(new Error(message)),
-      () => Promise.resolve(event)
+      () => Promise.resolve(event.input)
     )
   );
 


### PR DESCRIPTION
Output from RequireCmrFile did not properly align with expected input structure for SyncGranule. Also, fix rule name for WV04 smoke test rule.