### PR TITLE
Fix bad reference to background job

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - main
     paths:
+      - '.github/workflows/**'
       - 'app/**'
       - '!app/stacks/cumulus/resources/**'
       - 'config/**'
@@ -19,6 +20,7 @@ on:
     branches:
       - main
     paths:
+      - '.github/workflows/**'
       - 'app/**'
       - '!app/stacks/cumulus/resources/**'
       - 'config/**'

--- a/.github/workflows/terraspace.yml
+++ b/.github/workflows/terraspace.yml
@@ -104,6 +104,8 @@ jobs:
           echo "Node version: $(node --version)"
           bundle exec terraspace logs -f &
           bundle exec terraspace all plan
+          # Kill background logs job
+          kill $!
 
       - name: Deploy Cumulus
         if: ${{ inputs.deploy }}
@@ -112,4 +114,4 @@ jobs:
           bundle exec terraspace logs -f &
           bundle exec terraspace all up --yes
           # Kill background logs job
-          kill $$!
+          kill $!


### PR DESCRIPTION
Fix `$$!` to `$!` to refer to background job id for killing backgound log job.