### PR TITLE
Move launchpad.pfx to binary secret

### DIFF
--- a/bin/transfer-launchpad-pfx-secret.sh
+++ b/bin/transfer-launchpad-pfx-secret.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+declare secret_id="cumulus-launchpad-pfx"
+
+function usage() {
+  echo "Usage: ${0} SRC_AWS_PROFILE DST_AWS_PROFILE"
+  echo
+  echo "Transfers the AWS secret named '${secret_id}' from the source account"
+  echo "to the destination account, where the accounts are specified by their"
+  echo "AWS profile names, as defined on your system."
+}
+
+function die() {
+  echo "ERROR: ${1}" 2>&1
+  echo
+  usage
+  exit 1
+}
+
+function main() {
+  [[ ${#} == 0 ]] && die "No profiles specified"
+  [[ ${#} == 1 ]] && die "Destination profile not specified"
+  [[ ${#} != 2 ]] && die "Too many arguments specified"
+
+  declare src_aws_profile=${1}
+  declare dst_aws_profile=${2}
+
+  AWS_PROFILE="${src_aws_profile}" aws secretsmanager get-secret-value \
+    --secret-id cumulus-launchpad-pfx \
+    --output text \
+    --query SecretBinary |
+    AWS_PROFILE="${dst_aws_profile}" xargs -L1 aws secretsmanager create-secret \
+      --name cumulus-launchpad-pfx \
+      --secret-binary
+}
+
+main "${@}"

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "csdap-cumulus",
   "version": "1.0.0",
-  "description": "CSDAP Cumulus",
+  "description": "CSDA Cumulus",
   "main": "build/main/index.js",
   "typings": "build/main/index.d.ts",
-  "repository": "https://github.com/chuckwondo/csdap-cumulus",
+  "repository": "https://github.com/NASA-IMPACT/csdap-cumulus",
   "license": "MIT",
   "keywords": [],
   "private": true,


### PR DESCRIPTION
In preparation for deploying to CBA accounts, this moves the launchpad.pfx file to a binary secret as the source location from which copies are made to stack-specific S3 locations. This removes the problem caused by relying on a specific bucket as the source location from which to copy it, because bucket names must be universally unique, so using a bucket as the source location makes the copy process account-dependent. Using a secret instead makes the copy process account-independent.