### PR TITLE
Make nuke script auto-retry upon failure

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -87,6 +87,8 @@ RUN : \
   && ln -s "$(which cumulus)" /usr/local/bin/cumulus \
   && :
 
+WORKDIR /work
+
 # Install node dependencies
 COPY package.json yarn.lock ./
 # hadolint ignore=SC1091

--- a/Makefile
+++ b/Makefile
@@ -129,6 +129,7 @@ logs-init: docker
 	# Make sure all log/init/*.log files exist so we can tail them.  Oddly,
 	# terraspace appends a carriage return ('\r' or ^M) to each stack name, so we
 	# have to delete the trailing carriage returns before further piping.
+	rm -rf log
 	mkdir -p log/{init,plan,up}
 	$(TERRASPACE) list --type stack | tr -d '\r' | xargs -L1 basename | xargs -I{} touch log/{init,plan,up}/{}.log
 

--- a/Makefile
+++ b/Makefile
@@ -134,7 +134,7 @@ logs-init: docker
 
 ## nuke: DANGER! Completely annihilates your Cumulus stack (after confirmation)
 nuke: docker
-	$(DOCKER_RUN) $(IMAGE) -ic "bin/nuke.sh"
+	$(DOCKER_RUN) -i $(IMAGE) -ic "bin/nuke.sh"
 
 ## output-STACK: Runs `terraform output` for specified STACK
 output-%: docker

--- a/bin/nuke.sh
+++ b/bin/nuke.sh
@@ -64,7 +64,7 @@ if [[ -n "${_dynamo_db_tables}" ]]; then
   done
 fi
 
-_rds_cluster_id=$(
+_rds_cluster_ids=$(
   aws rds describe-db-clusters \
     --query "DBClusters[?contains(DBClusterIdentifier, '${CUMULUS_PREFIX}')].DBClusterIdentifier" \
     --output text
@@ -73,15 +73,17 @@ _rds_cluster_id=$(
 # If the RDS Cluster exists, destroy the data-persistence module as well as the
 # cluster.  This check also allows this script to be re-run without issue in the
 # event that something went wrong.
-if [[ -n "${_rds_cluster_id}" ]]; then
+if [[ -n "${_rds_cluster_ids}" ]]; then
   terraspace down data-persistence -y
 
-  AWS_PAGER="" aws rds modify-db-cluster \
-    --no-deletion-protection \
-    --db-cluster-identifier "${_rds_cluster_id}"
-  AWS_PAGER="" aws rds delete-db-cluster \
-    --skip-final-snapshot \
-    --db-cluster-identifier "${_rds_cluster_id}"
+  for _rds_cluster_id in ${_rds_cluster_ids}; do
+    AWS_PAGER="" aws rds modify-db-cluster \
+      --no-deletion-protection \
+      --db-cluster-identifier "${_rds_cluster_id}"
+    AWS_PAGER="" aws rds delete-db-cluster \
+      --skip-final-snapshot \
+      --db-cluster-identifier "${_rds_cluster_id}"
+  done
 fi
 
 terraspace down rds-cluster -y

--- a/bin/nuke.sh
+++ b/bin/nuke.sh
@@ -1,8 +1,25 @@
 #!/usr/bin/env bash
 
-set -euo pipefail
+set -Eeuo pipefail
+trap 'retry $? $LINENO' ERR
 
 _confirmation_phrase="destroy ${TS_ENV}"
+_attempts=${1:-1}
+
+retry() {
+  echo
+  echo -n "ERROR ${1} on line ${2}.  "
+
+  if [[ ${_attempts} -ge 10 ]]; then
+    echo "Giving up after ${_attempts} attempts."
+    exit "${1}"
+  else
+    echo "Retrying..."
+    echo
+    "${BASH_SOURCE[0]}" $((_attempts + 1)) <<<"${_confirmation_phrase}"
+    exit 0
+  fi
+}
 
 echo ""
 echo ">>> DANGER! <<<"


### PR DESCRIPTION
Since terraform commands might fail for various, transient reasons, make
`nuke.sh` automatically retry itself up to a total of 10 attempts before
giving up. This avoids the hassle of having to monitor its execution and
manually rerun it multiple times until all resources are destroyed.