### PR TITLE
Add UAT sample rule for WV03_MSI_L1B collection

### DIFF
--- a/app/stacks/cumulus/resources/rules/WV03_MSI_L1B/v1/WV03_MSI_L1B___1_UAT.json
+++ b/app/stacks/cumulus/resources/rules/WV03_MSI_L1B/v1/WV03_MSI_L1B___1_UAT.json
@@ -1,0 +1,23 @@
+{
+  "name": "WV03_MSI_L1B___1_UAT",
+  "state": "DISABLED",
+  "rule": {
+    "type": "onetime"
+  },
+  "provider": "maxar",
+  "collection": {
+    "name": "WV03_MSI_L1B",
+    "version": "1"
+  },
+  "workflow": "DiscoverAndQueueGranules",
+  "meta": {
+    "discoverOnly": false,
+    "providerPathFormat": "'css/nga/WV03/1B/'yyyy/DDD",
+    "rule": {
+      "state": "DISABLED"
+    },
+    "startDate": "2014-08-28T00:00:00Z",
+    "endDate": "2014-09-07T00:00:00Z",
+    "step": "P1D"
+  }
+}


### PR DESCRIPTION
I used Athena to find a date range that has 171 granules by doing the following:

- In the MCP IMPACT-CSDAP AWS account's console, open the Athena query editor
- Select the AwsDataCatalog Data Source and the default Database
- Run the following query to update the partitions: `MSCK REPAIR TABLE maxar_transfer`
- Run queries of the following form until a count near the 100-200 range is obtained:
   ```
   SELECT count(*) FROM maxar_transfer WHERE dt='2023-02-28-01-00' AND key like 'css/nga/WV03/1B/2014/24%M1BS%BROWSE.jpg'
   ```
   This particular query returned a value of 171, counting all `*BROWSE.jpg` files from the days 240-249 in 2014.

This approach uses the count of `*BROWSE.jpg` files as a proxy for the number of granules in the date range.

**NOTE:** the value of `dt` in the query above must be set to the most recent date of the S3 inventory (likely the current date, but the day prior to the current date should always work since the most recent 3 days are retained).

Next, days 2014/240 and 2014/249+1 (because the end date is exclusive in the rule definition) must be converted to `yyyy/MM/DD` for determining ISO 8601 datetime values for the start and end dates for the sample rule. This site provides conversion: https://dqydj.com/day-of-the-year-calculator/

- 2014/240 is `2014/08/28T00:00:00Z`
- 2014/250 is `2014/09/07T00:00:00Z`

This PR adds a UAT sample rule using this date range to limit ingestion to the 100-200 granules range.