### PR TITLE
Set granule queue batch size to 5

### DIFF
--- a/app/stacks/cumulus/resources/collections/WV02_MSI_L1B___1.json
+++ b/app/stacks/cumulus/resources/collections/WV02_MSI_L1B___1.json
@@ -6,6 +6,9 @@
   "granuleIdExtraction": "^(WV02_.+-M1BS-.+_P\\d{3}).+$",
   "sampleFileName": "WV02_20140824082814_10400100012AD900_14AUG24082814-M1BS-504548417070_01_P001-BROWSE.jpg",
   "url_path": "{cmrMetadata.CollectionReference.ShortName}___{cmrMetadata.CollectionReference.Version}/{dateFormat(cmrMetadata.TemporalExtent.SingleDateTime, YYYY)}/{dateFormat(cmrMetadata.TemporalExtent.SingleDateTime, DDD)}/{cmrMetadata.GranuleUR}",
+  "meta": {
+    "preferredQueueBatchSize": 5
+  },
   "ignoreFilesConfigForDiscovery": false,
   "files": [
     {

--- a/app/stacks/cumulus/resources/collections/WV03_MSI_L1B___1.json
+++ b/app/stacks/cumulus/resources/collections/WV03_MSI_L1B___1.json
@@ -6,6 +6,9 @@
   "granuleIdExtraction": "^(WV03_.+-M1BS-.+_P\\d{3}).+(?<!rename)$",
   "sampleFileName": "WV03_20140824082814_10400100012AD900_14AUG24082814-M1BS-504548417070_01_P001-BROWSE.jpg",
   "url_path": "{cmrMetadata.CollectionReference.ShortName}___{cmrMetadata.CollectionReference.Version}/{dateFormat(cmrMetadata.TemporalExtent.SingleDateTime, YYYY)}/{dateFormat(cmrMetadata.TemporalExtent.SingleDateTime, DDD)}/{cmrMetadata.GranuleUR}",
+  "meta": {
+    "preferredQueueBatchSize": 5
+  },
   "ignoreFilesConfigForDiscovery": false,
   "files": [
     {

--- a/app/stacks/cumulus/resources/collections/WV04_MSI_L1B___1.json
+++ b/app/stacks/cumulus/resources/collections/WV04_MSI_L1B___1.json
@@ -6,6 +6,9 @@
   "granuleIdExtraction": "^(WV04_.+-M1BS-.+_P\\d{3}).+(?<!rename)$",
   "sampleFileName": "WV04_20170504052256_f9ca790e-2502-46a6-9918-205faa15cd4c-inv_17MAY04052256-M1BS-059097041070_01_P001-BROWSE.jpg",
   "url_path": "{cmrMetadata.CollectionReference.ShortName}___{cmrMetadata.CollectionReference.Version}/{dateFormat(cmrMetadata.TemporalExtent.SingleDateTime, YYYY)}/{dateFormat(cmrMetadata.TemporalExtent.SingleDateTime, DDD)}/{cmrMetadata.GranuleUR}",
+  "meta": {
+    "preferredQueueBatchSize": 5
+  },
   "ignoreFilesConfigForDiscovery": false,
   "files": [
     {


### PR DESCRIPTION
The default granule batch size is 1, and this size indicates how many granules are batched up into a single SQS message during discovery. This bumps the batch size to 5 for all of the WorldView collections to speed up ingestion.

For the WV collections, the batch sizes were left unset, this defaulting to 1, because the lambda function to compute checksums would timeout for the very large data files in the collections. However, since checksums are already available in the UMM-G metadata files (*cmr.json), the workflow has been modified to simply pull the checksums out of the metadata files instead of recomputing them. This means that there is no longer any concern about timeouts for this step, so we can bump up the batch size without concern for timeouts.

Based on very rough calculations of the throughput of WV03_MSI_L1B___1 for the year 2015, bumping the batch size to 5 should perhaps put us at around 1000 CMR posts per minute. Once granules for the year 2016 are ingested, we'll recalculate to see if we can push the batch size higher for even greater throughput, but staying within the soft max of 2000 CMR posts per minute.