### PR TITLE
Speedup ingestion

### DIFF
--- a/app/stacks/cumulus/main.tf
+++ b/app/stacks/cumulus/main.tf
@@ -151,7 +151,7 @@ resource "aws_cloudwatch_event_target" "background_job_queue_watcher" {
   arn  = module.cumulus.sqs2sfThrottle_lambda_function_arn
   input = jsonencode(
     {
-      messageLimit = 250
+      messageLimit = 800
       queueUrl     = aws_sqs_queue.background_job_queue.id
       timeLimit    = 60
     }
@@ -510,7 +510,7 @@ module "cumulus" {
     {
       id              = "backgroundJobQueue",
       url             = aws_sqs_queue.background_job_queue.id,
-      execution_limit = 125
+      execution_limit = 400
     }
   ]
 }

--- a/app/stacks/cumulus/resources/collections/WV03_MSI_L1B___1.json
+++ b/app/stacks/cumulus/resources/collections/WV03_MSI_L1B___1.json
@@ -7,7 +7,7 @@
   "sampleFileName": "WV03_20140824082814_10400100012AD900_14AUG24082814-M1BS-504548417070_01_P001-BROWSE.jpg",
   "url_path": "{cmrMetadata.CollectionReference.ShortName}___{cmrMetadata.CollectionReference.Version}/{dateFormat(cmrMetadata.TemporalExtent.SingleDateTime, YYYY)}/{dateFormat(cmrMetadata.TemporalExtent.SingleDateTime, DDD)}/{cmrMetadata.GranuleUR}",
   "meta": {
-    "preferredQueueBatchSize": 5
+    "preferredQueueBatchSize": 10
   },
   "ignoreFilesConfigForDiscovery": false,
   "files": [

--- a/app/stacks/cumulus/resources/rules/WV03_MSI_L1B/v1/WV03_MSI_L1B___1_2017_Q1.json
+++ b/app/stacks/cumulus/resources/rules/WV03_MSI_L1B/v1/WV03_MSI_L1B___1_2017_Q1.json
@@ -1,0 +1,23 @@
+{
+  "name": "WV03_MSI_L1B___1_2017_Q1",
+  "state": "DISABLED",
+  "rule": {
+    "type": "onetime"
+  },
+  "provider": "maxar",
+  "collection": {
+    "name": "WV03_MSI_L1B",
+    "version": "1"
+  },
+  "workflow": "DiscoverAndQueueGranules",
+  "meta": {
+    "discoverOnly": false,
+    "providerPathFormat": "'css/nga/WV03/1B/'yyyy/DDD",
+    "rule": {
+      "state": "DISABLED"
+    },
+    "startDate": "2017-01-01T00:00:00Z",
+    "endDate": "2017-04-01T00:00:00Z",
+    "step": "P1D"
+  }
+}

--- a/app/stacks/cumulus/resources/rules/WV03_MSI_L1B/v1/WV03_MSI_L1B___1_2017_Q2.json
+++ b/app/stacks/cumulus/resources/rules/WV03_MSI_L1B/v1/WV03_MSI_L1B___1_2017_Q2.json
@@ -1,0 +1,23 @@
+{
+  "name": "WV03_MSI_L1B___1_2017_Q2",
+  "state": "DISABLED",
+  "rule": {
+    "type": "onetime"
+  },
+  "provider": "maxar",
+  "collection": {
+    "name": "WV03_MSI_L1B",
+    "version": "1"
+  },
+  "workflow": "DiscoverAndQueueGranules",
+  "meta": {
+    "discoverOnly": false,
+    "providerPathFormat": "'css/nga/WV03/1B/'yyyy/DDD",
+    "rule": {
+      "state": "DISABLED"
+    },
+    "startDate": "2017-04-01T00:00:00Z",
+    "endDate": "2017-07-01T00:00:00Z",
+    "step": "P1D"
+  }
+}


### PR DESCRIPTION
For ingesting granules from WV03_MSI_L1B for 2017 Q2, we ingested 60868 granules in about 2h50m, giving us a rate of ~21.5K granules/hr or ~360 granules/min. We want to get this rate over 1000 granules/min, but we'll need to do a bit of experimentation since there are a few "knobs" that affect our throughput.

For 2017 Q2, we increased our throughput by ~2.7x (from ~133/min [8K/hr] to ~360/min) simply by increasing the "preferredQueueBatchSize" from 1 (default) to 5, and that seemed to allow the IngestAndPublishGranule workflow to keep pace with the DiscoverAndQueueGranules workflow because the last execution of IngestAndPublishGranule (for 2017 Q2) finished only about a minute after the completion of its parent DiscoverAndQueueGranules workflow, which is about the average execution time for IngestAndPublishGranule.

Therefore, this seems to indicate that DiscoverAndQueueGranules is now the bottleneck, so this PR increases the execution limit by a bit more than 3x (from 125 to 400), and it also sets the preferredQueueBatchSize for 2017 Q2 to 10 (instead of only 5 as set for Q1). I chose to increase by 2x rather than 3x to see if this still keeps pace with DiscoverAndQueueGranules, without potentially overwhelming the CMR with requests for publishing metadata.

If this indeed gives us approximately linear increase in throughput, this should get us a bit over the 1000K/min, hopefully without either overwhelming the CMR or hitting AWS Lambda execution limits.

After 2017 Q2 is ingested, we can reassess to determine if (1) we can increase things further, if we still have some headroom, (2) keep things as configured by this PR, if throughput looks good, or (3) dial back a bit, if we encounter either CMR or Lambda issues.