### PR TITLE
Set custom domain name for Prod Distribution URL

### DIFF
--- a/app/stacks/cumulus/main.tf
+++ b/app/stacks/cumulus/main.tf
@@ -439,9 +439,10 @@ module "cumulus" {
   rds_security_group         = local.rds_security_group
   rds_user_access_secret_arn = local.rds_user_access_secret_arn
 
-  urs_url             = var.urs_url
-  urs_client_id       = data.aws_ssm_parameter.urs_client_id.value
-  urs_client_password = data.aws_ssm_parameter.urs_client_password.value
+  # These are no longer used, but are required by the module, so we simply set
+  # them to empty strings.
+  urs_client_id       = ""
+  urs_client_password = ""
 
   # <% if !(in_cba? && in_sandbox?) then %>
   metrics_es_host     = data.aws_ssm_parameter.metrics_es_host.value == "TBD" ? null : data.aws_ssm_parameter.metrics_es_host.value

--- a/app/stacks/cumulus/resources/collections/WV03_MSI_L1B___1.json
+++ b/app/stacks/cumulus/resources/collections/WV03_MSI_L1B___1.json
@@ -7,7 +7,7 @@
   "sampleFileName": "WV03_20140824082814_10400100012AD900_14AUG24082814-M1BS-504548417070_01_P001-BROWSE.jpg",
   "url_path": "{cmrMetadata.CollectionReference.ShortName}___{cmrMetadata.CollectionReference.Version}/{dateFormat(cmrMetadata.TemporalExtent.SingleDateTime, YYYY)}/{dateFormat(cmrMetadata.TemporalExtent.SingleDateTime, DDD)}/{cmrMetadata.GranuleUR}",
   "meta": {
-    "preferredQueueBatchSize": 10
+    "preferredQueueBatchSize": 1
   },
   "ignoreFilesConfigForDiscovery": false,
   "files": [

--- a/app/stacks/cumulus/resources/rules/WV03_MSI_L1B/v1/WV03_MSI_L1B___1_2017_04.json
+++ b/app/stacks/cumulus/resources/rules/WV03_MSI_L1B/v1/WV03_MSI_L1B___1_2017_04.json
@@ -1,0 +1,23 @@
+{
+  "name": "WV03_MSI_L1B___1_2017_04",
+  "state": "DISABLED",
+  "rule": {
+    "type": "onetime"
+  },
+  "provider": "maxar",
+  "collection": {
+    "name": "WV03_MSI_L1B",
+    "version": "1"
+  },
+  "workflow": "DiscoverAndQueueGranules",
+  "meta": {
+    "discoverOnly": false,
+    "providerPathFormat": "'css/nga/WV03/1B/'yyyy/DDD",
+    "rule": {
+      "state": "DISABLED"
+    },
+    "startDate": "2017-04-01T00:00:00Z",
+    "endDate": "2017-05-01T00:00:00Z",
+    "step": "P1D"
+  }
+}

--- a/app/stacks/cumulus/resources/rules/WV03_MSI_L1B/v1/WV03_MSI_L1B___1_2017_05_onwards.json
+++ b/app/stacks/cumulus/resources/rules/WV03_MSI_L1B/v1/WV03_MSI_L1B___1_2017_05_onwards.json
@@ -1,0 +1,23 @@
+{
+  "name": "WV03_MSI_L1B___1_2017_05_onwards",
+  "state": "DISABLED",
+  "rule": {
+    "type": "onetime"
+  },
+  "provider": "maxar",
+  "collection": {
+    "name": "WV03_MSI_L1B",
+    "version": "1"
+  },
+  "workflow": "DiscoverAndQueueGranules",
+  "meta": {
+    "discoverOnly": false,
+    "providerPathFormat": "'css/nga/WV03/1B/'yyyy/DDD",
+    "rule": {
+      "state": "DISABLED"
+    },
+    "startDate": "2017-05-01T00:00:00Z",
+    "endDate": "2018-01-01T00:00:00Z",
+    "step": "P1D"
+  }
+}

--- a/app/stacks/cumulus/ssm_parameters.rb
+++ b/app/stacks/cumulus/ssm_parameters.rb
@@ -59,17 +59,3 @@ if !(in_cba? && in_sandbox?) then
     name: "/shared/cumulus/metrics-es-password"
   )
 end
-
-# ------------------------------------------------------------------------------
-# STACK-SPECIFIC (not shared across stacks)
-# ------------------------------------------------------------------------------
-
-data("aws_ssm_parameter", "urs_client_id",
-  "//": "Earthdata Login (EDL) Application Client ID",
-  name: expansion("/:ENV/cumulus/urs-client-id")
-)
-
-data("aws_ssm_parameter", "urs_client_password",
-  "//": "Earthdata Login (EDL) Application Password",
-  name: expansion("/:ENV/cumulus/urs-client-password")
-)

--- a/app/stacks/cumulus/tfvars/base.tfvars
+++ b/app/stacks/cumulus/tfvars/base.tfvars
@@ -15,7 +15,6 @@
 #<% depends_on("rds-cluster") %>
 
 cmr_environment = "UAT"
-urs_url         = "https://uat.urs.earthdata.nasa.gov"
 
 system_bucket = "<%= bucket('internal') %>"
 

--- a/app/stacks/cumulus/tfvars/prod.tfvars
+++ b/app/stacks/cumulus/tfvars/prod.tfvars
@@ -5,9 +5,8 @@ cmr_environment = "OPS"
 #cumulus_distribution_url    = "TBD"
 # <% else %>
 # Trailing slash is required
-cumulus_distribution_url = "https://dy8riyaot0kde.cloudfront.net/"
+cumulus_distribution_url = "https://data.csda.earthdata.nasa.gov/"
 # <% end %>
 
 s3_replicator_target_bucket = "esdis-metrics-inbound-prod-csdap-distribution"
 s3_replicator_target_prefix = "input/s3_access/csdapprod"
-urs_url                     = "https://urs.earthdata.nasa.gov"

--- a/app/stacks/cumulus/variables.tf
+++ b/app/stacks/cumulus/variables.tf
@@ -201,8 +201,3 @@ variable "tags" {
   type        = map(string)
   default     = {}
 }
-
-variable "urs_url" {
-  description = "The URL of the Earthdata login (URS) site"
-  type        = string
-}


### PR DESCRIPTION
In addition:

- Set preferredQueueBatchSize back to 1 for WV03_MSI_L1B to reduce chances of overloading the CMR. This still allows the IngestAndPublish workflow to keep pace with the DiscoverAndQueueGranules workflow, so it's more of a precaution to prevent overloading the CMR in the event that DiscoverAndQueueGranules is ever made more performant.
- Add missing WV03_MSI_L1B rules for ingesting April (already done), and from May onwards (once metadata is generated)
- Remove obsolete SSM parameters for EDL credentials (no longer used)