### PR TITLE
Enable updating CMR links

### DIFF
--- a/.github/workflows/pass.yml
+++ b/.github/workflows/pass.yml
@@ -1,4 +1,4 @@
-name: Cumulus
+name: Non-Infrastructure Changes
 on:
   pull_request:
     types:
@@ -17,7 +17,7 @@ on:
       - '.editorconfig'
 
 jobs:
-  build:
+  succeed-uat:
     runs-on: ubuntu-20.04
     environment: uat
     steps:

--- a/_templates/rule/new/prompt.js
+++ b/_templates/rule/new/prompt.js
@@ -5,22 +5,27 @@ module.exports = [
   {
     type: 'input',
     name: 'provider',
-    message: "Provider ID:"
+    message: "Provider ID (example: maxar):"
   },
   {
     type: 'input',
     name: 'collectionName',
-    message: "Collection name:"
+    message: "Collection name (example: WV03_MSI_L1B):"
   },
   {
     type: 'input',
     name: 'collectionVersion',
-    message: "Collection version:"
+    message: "Collection version (example: 1):"
   },
   {
     type: 'input',
     name: 'providerPathFormat',
     message: "Provider path format (example: 'css/nga/WV03/1B/'yyyy/DDD):"
+  },
+  {
+    type: 'input',
+    name: 'ingestedPathFormat',
+    message: "Ingested path format (example: 'WV03_MSI_L1B___1/'yyyy/DDD):"
   },
   {
     type: 'input',

--- a/_templates/rule/new/rule.ejs.t
+++ b/_templates/rule/new/rule.ejs.t
@@ -6,6 +6,7 @@ message: >
   --collection-name <%= collectionName %>
   --collection-version <%= collectionVersion %>
   --provider-path-format "<%- providerPathFormat %>"
+  --ingested-path-format "<%- ingestedPathFormat %>"
   --year <%= year %>
 ---
 {
@@ -23,6 +24,7 @@ message: >
   "meta": {
     "discoverOnly": false,
     "providerPathFormat": "<%- providerPathFormat %>",
+    "ingestedPathFormat": "<%- ingestedPathFormat %>",
     "rule": {
       "state": "DISABLED"
     },
@@ -31,4 +33,3 @@ message: >
     "step": "P1D"
   }
 }
-

--- a/app/stacks/cumulus/resources/collections/WV03_MSI_L1B___1.json
+++ b/app/stacks/cumulus/resources/collections/WV03_MSI_L1B___1.json
@@ -7,7 +7,7 @@
   "sampleFileName": "WV03_20140824082814_10400100012AD900_14AUG24082814-M1BS-504548417070_01_P001-BROWSE.jpg",
   "url_path": "{cmrMetadata.CollectionReference.ShortName}___{cmrMetadata.CollectionReference.Version}/{dateFormat(cmrMetadata.TemporalExtent.SingleDateTime, YYYY)}/{dateFormat(cmrMetadata.TemporalExtent.SingleDateTime, DDD)}/{cmrMetadata.GranuleUR}",
   "meta": {
-    "preferredQueueBatchSize": 1
+    "preferredQueueBatchSize": 5
   },
   "ignoreFilesConfigForDiscovery": false,
   "files": [

--- a/app/stacks/cumulus/resources/rules/PSScene3Band/v1/PSScene3Band___1_2015.json
+++ b/app/stacks/cumulus/resources/rules/PSScene3Band/v1/PSScene3Band___1_2015.json
@@ -12,6 +12,7 @@
   },
   "meta": {
     "providerPathFormat": "'storage-ss-ingest-prod-ingesteddata-uswest2/planet/PSScene3Band-'yyyy",
+    "ingestedPathFormat": "'planet/PSScene3Band/'yyyyMMdd_HH",
     "startDate": "2015-01-01T00:00:00Z",
     "endDate": "2016-01-01T00:00:00Z",
     "step": "P1Y",

--- a/app/stacks/cumulus/resources/rules/PSScene3Band/v1/PSScene3Band___1_2016.json
+++ b/app/stacks/cumulus/resources/rules/PSScene3Band/v1/PSScene3Band___1_2016.json
@@ -12,6 +12,7 @@
   },
   "meta": {
     "providerPathFormat": "'storage-ss-ingest-prod-ingesteddata-uswest2/planet/PSScene3Band-'yyyyMM",
+    "ingestedPathFormat": "'planet/PSScene3Band/'yyyyMMdd_HH",
     "startDate": "2016-01-01T00:00:00Z",
     "endDate": "2017-01-01T00:00:00Z",
     "step": "P1M",

--- a/app/stacks/cumulus/resources/rules/PSScene3Band/v1/PSScene3Band___1_2017.json
+++ b/app/stacks/cumulus/resources/rules/PSScene3Band/v1/PSScene3Band___1_2017.json
@@ -12,6 +12,7 @@
   },
   "meta": {
     "providerPathFormat": "'storage-ss-ingest-prod-ingesteddata-uswest2/planet/PSScene3Band-'yyyyMMdd",
+    "ingestedPathFormat": "'planet/PSScene3Band/'yyyyMMdd_HH",
     "startDate": "2017-01-01T00:00:00Z",
     "endDate": "2018-01-01T00:00:00Z",
     "step": "P1D",

--- a/app/stacks/cumulus/resources/rules/PSScene3Band/v1/PSScene3Band___1_2018.json
+++ b/app/stacks/cumulus/resources/rules/PSScene3Band/v1/PSScene3Band___1_2018.json
@@ -12,6 +12,7 @@
   },
   "meta": {
     "providerPathFormat": "'storage-ss-ingest-prod-ingesteddata-uswest2/planet/PSScene3Band-'yyyyMMdd",
+    "ingestedPathFormat": "'planet/PSScene3Band/'yyyyMMdd_HH",
     "startDate": "2018-01-01T00:00:00Z",
     "endDate": "2019-01-01T00:00:00Z",
     "step": "P1D",

--- a/app/stacks/cumulus/resources/rules/PSScene3Band/v1/PSScene3Band___1_2019.json
+++ b/app/stacks/cumulus/resources/rules/PSScene3Band/v1/PSScene3Band___1_2019.json
@@ -12,6 +12,7 @@
   },
   "meta": {
     "providerPathFormat": "'storage-ss-ingest-prod-ingesteddata-uswest2/planet/PSScene3Band-'yyyyMMdd",
+    "ingestedPathFormat": "'planet/PSScene3Band/'yyyyMMdd_HH",
     "startDate": "2019-01-01T00:00:00Z",
     "endDate": "2020-01-01T00:00:00Z",
     "step": "P1D",

--- a/app/stacks/cumulus/resources/rules/PSScene3Band/v1/PSScene3Band___1_2020.json
+++ b/app/stacks/cumulus/resources/rules/PSScene3Band/v1/PSScene3Band___1_2020.json
@@ -12,6 +12,7 @@
   },
   "meta": {
     "providerPathFormat": "'storage-ss-ingest-prod-ingesteddata-uswest2/planet/PSScene3Band-'yyyyMMdd",
+    "ingestedPathFormat": "'planet/PSScene3Band/'yyyyMMdd_HH",
     "startDate": "2020-01-01T00:00:00Z",
     "endDate": "2021-01-01T00:00:00Z",
     "step": "P1D",

--- a/app/stacks/cumulus/resources/rules/PSScene3Band/v1/PSScene3Band___1_SmokeTest.json
+++ b/app/stacks/cumulus/resources/rules/PSScene3Band/v1/PSScene3Band___1_SmokeTest.json
@@ -12,6 +12,7 @@
   },
   "meta": {
     "providerPathFormat": "'storage-ss-ingest-prod-ingesteddata-uswest2/planet/PSScene3Band-'yyyyMMdd_HH",
+    "ingestedPathFormat": "'planet/PSScene3Band/'yyyyMMdd_HH",
     "startDate": "2017-12-01T03:00:00.000Z",
     "endDate": "2017-12-01T05:00:00.000Z",
     "step": "PT1H",

--- a/app/stacks/cumulus/resources/rules/WV01_Pan_L1B/v1/WV01_Pan_L1B___1_2007.json
+++ b/app/stacks/cumulus/resources/rules/WV01_Pan_L1B/v1/WV01_Pan_L1B___1_2007.json
@@ -13,6 +13,7 @@
   "meta": {
     "discoverOnly": false,
     "providerPathFormat": "'css/nga/WV01/1B/'yyyy/DDD",
+    "ingestedPathFormat": "'WV01_Pan_L1B___1/'yyyy/DDD",
     "rule": {
       "state": "DISABLED"
     },
@@ -21,4 +22,3 @@
     "step": "P1D"
   }
 }
-

--- a/app/stacks/cumulus/resources/rules/WV01_Pan_L1B/v1/WV01_Pan_L1B___1_2008.json
+++ b/app/stacks/cumulus/resources/rules/WV01_Pan_L1B/v1/WV01_Pan_L1B___1_2008.json
@@ -13,6 +13,7 @@
   "meta": {
     "discoverOnly": false,
     "providerPathFormat": "'css/nga/WV01/1B/'yyyy/DDD",
+    "ingestedPathFormat": "'WV01_Pan_L1B___1/'yyyy/DDD",
     "rule": {
       "state": "DISABLED"
     },
@@ -21,4 +22,3 @@
     "step": "P1D"
   }
 }
-

--- a/app/stacks/cumulus/resources/rules/WV01_Pan_L1B/v1/WV01_Pan_L1B___1_2009.json
+++ b/app/stacks/cumulus/resources/rules/WV01_Pan_L1B/v1/WV01_Pan_L1B___1_2009.json
@@ -13,6 +13,7 @@
   "meta": {
     "discoverOnly": false,
     "providerPathFormat": "'css/nga/WV01/1B/'yyyy/DDD",
+    "ingestedPathFormat": "'WV01_Pan_L1B___1/'yyyy/DDD",
     "rule": {
       "state": "DISABLED"
     },
@@ -21,4 +22,3 @@
     "step": "P1D"
   }
 }
-

--- a/app/stacks/cumulus/resources/rules/WV01_Pan_L1B/v1/WV01_Pan_L1B___1_2010.json
+++ b/app/stacks/cumulus/resources/rules/WV01_Pan_L1B/v1/WV01_Pan_L1B___1_2010.json
@@ -13,6 +13,7 @@
   "meta": {
     "discoverOnly": false,
     "providerPathFormat": "'css/nga/WV01/1B/'yyyy/DDD",
+    "ingestedPathFormat": "'WV01_Pan_L1B___1/'yyyy/DDD",
     "rule": {
       "state": "DISABLED"
     },
@@ -21,4 +22,3 @@
     "step": "P1D"
   }
 }
-

--- a/app/stacks/cumulus/resources/rules/WV01_Pan_L1B/v1/WV01_Pan_L1B___1_2011.json
+++ b/app/stacks/cumulus/resources/rules/WV01_Pan_L1B/v1/WV01_Pan_L1B___1_2011.json
@@ -13,6 +13,7 @@
   "meta": {
     "discoverOnly": false,
     "providerPathFormat": "'css/nga/WV01/1B/'yyyy/DDD",
+    "ingestedPathFormat": "'WV01_Pan_L1B___1/'yyyy/DDD",
     "rule": {
       "state": "DISABLED"
     },
@@ -21,4 +22,3 @@
     "step": "P1D"
   }
 }
-

--- a/app/stacks/cumulus/resources/rules/WV01_Pan_L1B/v1/WV01_Pan_L1B___1_2012.json
+++ b/app/stacks/cumulus/resources/rules/WV01_Pan_L1B/v1/WV01_Pan_L1B___1_2012.json
@@ -13,6 +13,7 @@
   "meta": {
     "discoverOnly": false,
     "providerPathFormat": "'css/nga/WV01/1B/'yyyy/DDD",
+    "ingestedPathFormat": "'WV01_Pan_L1B___1/'yyyy/DDD",
     "rule": {
       "state": "DISABLED"
     },
@@ -21,4 +22,3 @@
     "step": "P1D"
   }
 }
-

--- a/app/stacks/cumulus/resources/rules/WV01_Pan_L1B/v1/WV01_Pan_L1B___1_2013.json
+++ b/app/stacks/cumulus/resources/rules/WV01_Pan_L1B/v1/WV01_Pan_L1B___1_2013.json
@@ -13,6 +13,7 @@
   "meta": {
     "discoverOnly": false,
     "providerPathFormat": "'css/nga/WV01/1B/'yyyy/DDD",
+    "ingestedPathFormat": "'WV01_Pan_L1B___1/'yyyy/DDD",
     "rule": {
       "state": "DISABLED"
     },
@@ -21,4 +22,3 @@
     "step": "P1D"
   }
 }
-

--- a/app/stacks/cumulus/resources/rules/WV01_Pan_L1B/v1/WV01_Pan_L1B___1_2014.json
+++ b/app/stacks/cumulus/resources/rules/WV01_Pan_L1B/v1/WV01_Pan_L1B___1_2014.json
@@ -13,6 +13,7 @@
   "meta": {
     "discoverOnly": false,
     "providerPathFormat": "'css/nga/WV01/1B/'yyyy/DDD",
+    "ingestedPathFormat": "'WV01_Pan_L1B___1/'yyyy/DDD",
     "rule": {
       "state": "DISABLED"
     },
@@ -21,4 +22,3 @@
     "step": "P1D"
   }
 }
-

--- a/app/stacks/cumulus/resources/rules/WV01_Pan_L1B/v1/WV01_Pan_L1B___1_2015.json
+++ b/app/stacks/cumulus/resources/rules/WV01_Pan_L1B/v1/WV01_Pan_L1B___1_2015.json
@@ -13,6 +13,7 @@
   "meta": {
     "discoverOnly": false,
     "providerPathFormat": "'css/nga/WV01/1B/'yyyy/DDD",
+    "ingestedPathFormat": "'WV01_Pan_L1B___1/'yyyy/DDD",
     "rule": {
       "state": "DISABLED"
     },
@@ -21,4 +22,3 @@
     "step": "P1D"
   }
 }
-

--- a/app/stacks/cumulus/resources/rules/WV01_Pan_L1B/v1/WV01_Pan_L1B___1_2016.json
+++ b/app/stacks/cumulus/resources/rules/WV01_Pan_L1B/v1/WV01_Pan_L1B___1_2016.json
@@ -13,6 +13,7 @@
   "meta": {
     "discoverOnly": false,
     "providerPathFormat": "'css/nga/WV01/1B/'yyyy/DDD",
+    "ingestedPathFormat": "'WV01_Pan_L1B___1/'yyyy/DDD",
     "rule": {
       "state": "DISABLED"
     },
@@ -21,4 +22,3 @@
     "step": "P1D"
   }
 }
-

--- a/app/stacks/cumulus/resources/rules/WV01_Pan_L1B/v1/WV01_Pan_L1B___1_2017.json
+++ b/app/stacks/cumulus/resources/rules/WV01_Pan_L1B/v1/WV01_Pan_L1B___1_2017.json
@@ -13,6 +13,7 @@
   "meta": {
     "discoverOnly": false,
     "providerPathFormat": "'css/nga/WV01/1B/'yyyy/DDD",
+    "ingestedPathFormat": "'WV01_Pan_L1B___1/'yyyy/DDD",
     "rule": {
       "state": "DISABLED"
     },
@@ -21,4 +22,3 @@
     "step": "P1D"
   }
 }
-

--- a/app/stacks/cumulus/resources/rules/WV01_Pan_L1B/v1/WV01_Pan_L1B___1_2018.json
+++ b/app/stacks/cumulus/resources/rules/WV01_Pan_L1B/v1/WV01_Pan_L1B___1_2018.json
@@ -13,6 +13,7 @@
   "meta": {
     "discoverOnly": false,
     "providerPathFormat": "'css/nga/WV01/1B/'yyyy/DDD",
+    "ingestedPathFormat": "'WV01_Pan_L1B___1/'yyyy/DDD",
     "rule": {
       "state": "DISABLED"
     },
@@ -21,4 +22,3 @@
     "step": "P1D"
   }
 }
-

--- a/app/stacks/cumulus/resources/rules/WV01_Pan_L1B/v1/WV01_Pan_L1B___1_2019.json
+++ b/app/stacks/cumulus/resources/rules/WV01_Pan_L1B/v1/WV01_Pan_L1B___1_2019.json
@@ -13,6 +13,7 @@
   "meta": {
     "discoverOnly": false,
     "providerPathFormat": "'css/nga/WV01/1B/'yyyy/DDD",
+    "ingestedPathFormat": "'WV01_Pan_L1B___1/'yyyy/DDD",
     "rule": {
       "state": "DISABLED"
     },
@@ -21,4 +22,3 @@
     "step": "P1D"
   }
 }
-

--- a/app/stacks/cumulus/resources/rules/WV01_Pan_L1B/v1/WV01_Pan_L1B___1_2020.json
+++ b/app/stacks/cumulus/resources/rules/WV01_Pan_L1B/v1/WV01_Pan_L1B___1_2020.json
@@ -13,6 +13,7 @@
   "meta": {
     "discoverOnly": false,
     "providerPathFormat": "'css/nga/WV01/1B/'yyyy/DDD",
+    "ingestedPathFormat": "'WV01_Pan_L1B___1/'yyyy/DDD",
     "rule": {
       "state": "DISABLED"
     },
@@ -21,4 +22,3 @@
     "step": "P1D"
   }
 }
-

--- a/app/stacks/cumulus/resources/rules/WV01_Pan_L1B/v1/WV01_Pan_L1B___1_2021.json
+++ b/app/stacks/cumulus/resources/rules/WV01_Pan_L1B/v1/WV01_Pan_L1B___1_2021.json
@@ -13,6 +13,7 @@
   "meta": {
     "discoverOnly": false,
     "providerPathFormat": "'css/nga/WV01/1B/'yyyy/DDD",
+    "ingestedPathFormat": "'WV01_Pan_L1B___1/'yyyy/DDD",
     "rule": {
       "state": "DISABLED"
     },
@@ -21,4 +22,3 @@
     "step": "P1D"
   }
 }
-

--- a/app/stacks/cumulus/resources/rules/WV01_Pan_L1B/v1/WV01_Pan_L1B___1_2022.json
+++ b/app/stacks/cumulus/resources/rules/WV01_Pan_L1B/v1/WV01_Pan_L1B___1_2022.json
@@ -13,6 +13,7 @@
   "meta": {
     "discoverOnly": false,
     "providerPathFormat": "'css/nga/WV01/1B/'yyyy/DDD",
+    "ingestedPathFormat": "'WV01_Pan_L1B___1/'yyyy/DDD",
     "rule": {
       "state": "DISABLED"
     },
@@ -21,4 +22,3 @@
     "step": "P1D"
   }
 }
-

--- a/app/stacks/cumulus/resources/rules/WV01_Pan_L1B/v1/WV01_Pan_L1B___1_SmokeTest.json
+++ b/app/stacks/cumulus/resources/rules/WV01_Pan_L1B/v1/WV01_Pan_L1B___1_SmokeTest.json
@@ -13,6 +13,7 @@
   "meta": {
     "discoverOnly": false,
     "providerPathFormat": "'css/nga/WV01/1B/'yyyy/DDD",
+    "ingestedPathFormat": "'WV01_Pan_L1B___1/'yyyy/DDD",
     "rule": {
       "state": "DISABLED"
     },

--- a/app/stacks/cumulus/resources/rules/WV02_MSI_L1B/v1/WV02_MSI_L1B___1_2009.json
+++ b/app/stacks/cumulus/resources/rules/WV02_MSI_L1B/v1/WV02_MSI_L1B___1_2009.json
@@ -13,6 +13,7 @@
   "meta": {
     "discoverOnly": false,
     "providerPathFormat": "'css/nga/WV02/1B/'yyyy/DDD",
+    "ingestedPathFormat": "'WV02_MSI_L1B___1/'yyyy/DDD",
     "rule": {
       "state": "DISABLED"
     },

--- a/app/stacks/cumulus/resources/rules/WV02_MSI_L1B/v1/WV02_MSI_L1B___1_2010.json
+++ b/app/stacks/cumulus/resources/rules/WV02_MSI_L1B/v1/WV02_MSI_L1B___1_2010.json
@@ -13,6 +13,7 @@
   "meta": {
     "discoverOnly": false,
     "providerPathFormat": "'css/nga/WV02/1B/'yyyy/DDD",
+    "ingestedPathFormat": "'WV02_MSI_L1B___1/'yyyy/DDD",
     "rule": {
       "state": "DISABLED"
     },

--- a/app/stacks/cumulus/resources/rules/WV02_MSI_L1B/v1/WV02_MSI_L1B___1_2011.json
+++ b/app/stacks/cumulus/resources/rules/WV02_MSI_L1B/v1/WV02_MSI_L1B___1_2011.json
@@ -13,6 +13,7 @@
   "meta": {
     "discoverOnly": false,
     "providerPathFormat": "'css/nga/WV02/1B/'yyyy/DDD",
+    "ingestedPathFormat": "'WV02_MSI_L1B___1/'yyyy/DDD",
     "rule": {
       "state": "DISABLED"
     },

--- a/app/stacks/cumulus/resources/rules/WV02_MSI_L1B/v1/WV02_MSI_L1B___1_2012.json
+++ b/app/stacks/cumulus/resources/rules/WV02_MSI_L1B/v1/WV02_MSI_L1B___1_2012.json
@@ -13,6 +13,7 @@
   "meta": {
     "discoverOnly": false,
     "providerPathFormat": "'css/nga/WV02/1B/'yyyy/DDD",
+    "ingestedPathFormat": "'WV02_MSI_L1B___1/'yyyy/DDD",
     "rule": {
       "state": "DISABLED"
     },

--- a/app/stacks/cumulus/resources/rules/WV02_MSI_L1B/v1/WV02_MSI_L1B___1_2013.json
+++ b/app/stacks/cumulus/resources/rules/WV02_MSI_L1B/v1/WV02_MSI_L1B___1_2013.json
@@ -13,6 +13,7 @@
   "meta": {
     "discoverOnly": false,
     "providerPathFormat": "'css/nga/WV02/1B/'yyyy/DDD",
+    "ingestedPathFormat": "'WV02_MSI_L1B___1/'yyyy/DDD",
     "rule": {
       "state": "DISABLED"
     },

--- a/app/stacks/cumulus/resources/rules/WV02_MSI_L1B/v1/WV02_MSI_L1B___1_2014.json
+++ b/app/stacks/cumulus/resources/rules/WV02_MSI_L1B/v1/WV02_MSI_L1B___1_2014.json
@@ -13,6 +13,7 @@
   "meta": {
     "discoverOnly": false,
     "providerPathFormat": "'css/nga/WV02/1B/'yyyy/DDD",
+    "ingestedPathFormat": "'WV02_MSI_L1B___1/'yyyy/DDD",
     "rule": {
       "state": "DISABLED"
     },

--- a/app/stacks/cumulus/resources/rules/WV02_MSI_L1B/v1/WV02_MSI_L1B___1_2015.json
+++ b/app/stacks/cumulus/resources/rules/WV02_MSI_L1B/v1/WV02_MSI_L1B___1_2015.json
@@ -13,6 +13,7 @@
   "meta": {
     "discoverOnly": false,
     "providerPathFormat": "'css/nga/WV02/1B/'yyyy/DDD",
+    "ingestedPathFormat": "'WV02_MSI_L1B___1/'yyyy/DDD",
     "rule": {
       "state": "DISABLED"
     },

--- a/app/stacks/cumulus/resources/rules/WV02_MSI_L1B/v1/WV02_MSI_L1B___1_2016.json
+++ b/app/stacks/cumulus/resources/rules/WV02_MSI_L1B/v1/WV02_MSI_L1B___1_2016.json
@@ -13,6 +13,7 @@
   "meta": {
     "discoverOnly": false,
     "providerPathFormat": "'css/nga/WV02/1B/'yyyy/DDD",
+    "ingestedPathFormat": "'WV02_MSI_L1B___1/'yyyy/DDD",
     "rule": {
       "state": "DISABLED"
     },

--- a/app/stacks/cumulus/resources/rules/WV02_MSI_L1B/v1/WV02_MSI_L1B___1_2017.json
+++ b/app/stacks/cumulus/resources/rules/WV02_MSI_L1B/v1/WV02_MSI_L1B___1_2017.json
@@ -13,6 +13,7 @@
   "meta": {
     "discoverOnly": false,
     "providerPathFormat": "'css/nga/WV02/1B/'yyyy/DDD",
+    "ingestedPathFormat": "'WV02_MSI_L1B___1/'yyyy/DDD",
     "rule": {
       "state": "DISABLED"
     },

--- a/app/stacks/cumulus/resources/rules/WV02_MSI_L1B/v1/WV02_MSI_L1B___1_2018.json
+++ b/app/stacks/cumulus/resources/rules/WV02_MSI_L1B/v1/WV02_MSI_L1B___1_2018.json
@@ -13,6 +13,7 @@
   "meta": {
     "discoverOnly": false,
     "providerPathFormat": "'css/nga/WV02/1B/'yyyy/DDD",
+    "ingestedPathFormat": "'WV02_MSI_L1B___1/'yyyy/DDD",
     "rule": {
       "state": "DISABLED"
     },

--- a/app/stacks/cumulus/resources/rules/WV02_MSI_L1B/v1/WV02_MSI_L1B___1_2019.json
+++ b/app/stacks/cumulus/resources/rules/WV02_MSI_L1B/v1/WV02_MSI_L1B___1_2019.json
@@ -13,6 +13,7 @@
   "meta": {
     "discoverOnly": false,
     "providerPathFormat": "'css/nga/WV02/1B/'yyyy/DDD",
+    "ingestedPathFormat": "'WV02_MSI_L1B___1/'yyyy/DDD",
     "rule": {
       "state": "DISABLED"
     },

--- a/app/stacks/cumulus/resources/rules/WV02_MSI_L1B/v1/WV02_MSI_L1B___1_2020.json
+++ b/app/stacks/cumulus/resources/rules/WV02_MSI_L1B/v1/WV02_MSI_L1B___1_2020.json
@@ -13,6 +13,7 @@
   "meta": {
     "discoverOnly": false,
     "providerPathFormat": "'css/nga/WV02/1B/'yyyy/DDD",
+    "ingestedPathFormat": "'WV02_MSI_L1B___1/'yyyy/DDD",
     "rule": {
       "state": "DISABLED"
     },

--- a/app/stacks/cumulus/resources/rules/WV02_MSI_L1B/v1/WV02_MSI_L1B___1_2021.json
+++ b/app/stacks/cumulus/resources/rules/WV02_MSI_L1B/v1/WV02_MSI_L1B___1_2021.json
@@ -13,6 +13,7 @@
   "meta": {
     "discoverOnly": false,
     "providerPathFormat": "'css/nga/WV02/1B/'yyyy/DDD",
+    "ingestedPathFormat": "'WV02_MSI_L1B___1/'yyyy/DDD",
     "rule": {
       "state": "DISABLED"
     },

--- a/app/stacks/cumulus/resources/rules/WV02_MSI_L1B/v1/WV02_MSI_L1B___1_2022.json
+++ b/app/stacks/cumulus/resources/rules/WV02_MSI_L1B/v1/WV02_MSI_L1B___1_2022.json
@@ -13,6 +13,7 @@
   "meta": {
     "discoverOnly": false,
     "providerPathFormat": "'css/nga/WV02/1B/'yyyy/DDD",
+    "ingestedPathFormat": "'WV02_MSI_L1B___1/'yyyy/DDD",
     "rule": {
       "state": "DISABLED"
     },

--- a/app/stacks/cumulus/resources/rules/WV02_MSI_L1B/v1/WV02_MSI_L1B___1_SmokeTest.json
+++ b/app/stacks/cumulus/resources/rules/WV02_MSI_L1B/v1/WV02_MSI_L1B___1_SmokeTest.json
@@ -13,6 +13,7 @@
   "meta": {
     "discoverOnly": false,
     "providerPathFormat": "'css/nga/WV02/1B/'yyyy/DDD",
+    "ingestedPathFormat": "'WV02_MSI_L1B___1/'yyyy/DDD",
     "rule": {
       "state": "DISABLED"
     },

--- a/app/stacks/cumulus/resources/rules/WV02_MSI_L1B/v1/WV02_MSI_L1B___1_UAT.json
+++ b/app/stacks/cumulus/resources/rules/WV02_MSI_L1B/v1/WV02_MSI_L1B___1_UAT.json
@@ -13,6 +13,7 @@
   "meta": {
     "discoverOnly": false,
     "providerPathFormat": "'css/nga/WV02/1B/'yyyy/DDD",
+    "ingestedPathFormat": "'WV02_MSI_L1B___1/'yyyy/DDD",
     "rule": {
       "state": "DISABLED"
     },

--- a/app/stacks/cumulus/resources/rules/WV03_MSI_L1B/v1/WV03_MSI_L1B___1_2014.json
+++ b/app/stacks/cumulus/resources/rules/WV03_MSI_L1B/v1/WV03_MSI_L1B___1_2014.json
@@ -13,6 +13,7 @@
   "meta": {
     "discoverOnly": false,
     "providerPathFormat": "'css/nga/WV03/1B/'yyyy/DDD",
+    "ingestedPathFormat": "'WV03_MSI_L1B___1/'yyyy/DDD",
     "rule": {
       "state": "DISABLED"
     },

--- a/app/stacks/cumulus/resources/rules/WV03_MSI_L1B/v1/WV03_MSI_L1B___1_2015.json
+++ b/app/stacks/cumulus/resources/rules/WV03_MSI_L1B/v1/WV03_MSI_L1B___1_2015.json
@@ -13,6 +13,7 @@
   "meta": {
     "discoverOnly": false,
     "providerPathFormat": "'css/nga/WV03/1B/'yyyy/DDD",
+    "ingestedPathFormat": "'WV03_MSI_L1B___1/'yyyy/DDD",
     "rule": {
       "state": "DISABLED"
     },

--- a/app/stacks/cumulus/resources/rules/WV03_MSI_L1B/v1/WV03_MSI_L1B___1_2016.json
+++ b/app/stacks/cumulus/resources/rules/WV03_MSI_L1B/v1/WV03_MSI_L1B___1_2016.json
@@ -13,6 +13,7 @@
   "meta": {
     "discoverOnly": false,
     "providerPathFormat": "'css/nga/WV03/1B/'yyyy/DDD",
+    "ingestedPathFormat": "'WV03_MSI_L1B___1/'yyyy/DDD",
     "rule": {
       "state": "DISABLED"
     },

--- a/app/stacks/cumulus/resources/rules/WV03_MSI_L1B/v1/WV03_MSI_L1B___1_2017.json
+++ b/app/stacks/cumulus/resources/rules/WV03_MSI_L1B/v1/WV03_MSI_L1B___1_2017.json
@@ -13,6 +13,7 @@
   "meta": {
     "discoverOnly": false,
     "providerPathFormat": "'css/nga/WV03/1B/'yyyy/DDD",
+    "ingestedPathFormat": "'WV03_MSI_L1B___1/'yyyy/DDD",
     "rule": {
       "state": "DISABLED"
     },

--- a/app/stacks/cumulus/resources/rules/WV03_MSI_L1B/v1/WV03_MSI_L1B___1_2017_04.json
+++ b/app/stacks/cumulus/resources/rules/WV03_MSI_L1B/v1/WV03_MSI_L1B___1_2017_04.json
@@ -13,6 +13,7 @@
   "meta": {
     "discoverOnly": false,
     "providerPathFormat": "'css/nga/WV03/1B/'yyyy/DDD",
+    "ingestedPathFormat": "'WV03_MSI_L1B___1/'yyyy/DDD",
     "rule": {
       "state": "DISABLED"
     },

--- a/app/stacks/cumulus/resources/rules/WV03_MSI_L1B/v1/WV03_MSI_L1B___1_2017_05_onwards.json
+++ b/app/stacks/cumulus/resources/rules/WV03_MSI_L1B/v1/WV03_MSI_L1B___1_2017_05_onwards.json
@@ -13,6 +13,7 @@
   "meta": {
     "discoverOnly": false,
     "providerPathFormat": "'css/nga/WV03/1B/'yyyy/DDD",
+    "ingestedPathFormat": "'WV03_MSI_L1B___1/'yyyy/DDD",
     "rule": {
       "state": "DISABLED"
     },

--- a/app/stacks/cumulus/resources/rules/WV03_MSI_L1B/v1/WV03_MSI_L1B___1_2017_Q1.json
+++ b/app/stacks/cumulus/resources/rules/WV03_MSI_L1B/v1/WV03_MSI_L1B___1_2017_Q1.json
@@ -13,6 +13,7 @@
   "meta": {
     "discoverOnly": false,
     "providerPathFormat": "'css/nga/WV03/1B/'yyyy/DDD",
+    "ingestedPathFormat": "'WV03_MSI_L1B___1/'yyyy/DDD",
     "rule": {
       "state": "DISABLED"
     },

--- a/app/stacks/cumulus/resources/rules/WV03_MSI_L1B/v1/WV03_MSI_L1B___1_2017_Q2.json
+++ b/app/stacks/cumulus/resources/rules/WV03_MSI_L1B/v1/WV03_MSI_L1B___1_2017_Q2.json
@@ -13,6 +13,7 @@
   "meta": {
     "discoverOnly": false,
     "providerPathFormat": "'css/nga/WV03/1B/'yyyy/DDD",
+    "ingestedPathFormat": "'WV03_MSI_L1B___1/'yyyy/DDD",
     "rule": {
       "state": "DISABLED"
     },

--- a/app/stacks/cumulus/resources/rules/WV03_MSI_L1B/v1/WV03_MSI_L1B___1_2018.json
+++ b/app/stacks/cumulus/resources/rules/WV03_MSI_L1B/v1/WV03_MSI_L1B___1_2018.json
@@ -13,6 +13,7 @@
   "meta": {
     "discoverOnly": false,
     "providerPathFormat": "'css/nga/WV03/1B/'yyyy/DDD",
+    "ingestedPathFormat": "'WV03_MSI_L1B___1/'yyyy/DDD",
     "rule": {
       "state": "DISABLED"
     },

--- a/app/stacks/cumulus/resources/rules/WV03_MSI_L1B/v1/WV03_MSI_L1B___1_2019.json
+++ b/app/stacks/cumulus/resources/rules/WV03_MSI_L1B/v1/WV03_MSI_L1B___1_2019.json
@@ -13,6 +13,7 @@
   "meta": {
     "discoverOnly": false,
     "providerPathFormat": "'css/nga/WV03/1B/'yyyy/DDD",
+    "ingestedPathFormat": "'WV03_MSI_L1B___1/'yyyy/DDD",
     "rule": {
       "state": "DISABLED"
     },

--- a/app/stacks/cumulus/resources/rules/WV03_MSI_L1B/v1/WV03_MSI_L1B___1_2020.json
+++ b/app/stacks/cumulus/resources/rules/WV03_MSI_L1B/v1/WV03_MSI_L1B___1_2020.json
@@ -13,6 +13,7 @@
   "meta": {
     "discoverOnly": false,
     "providerPathFormat": "'css/nga/WV03/1B/'yyyy/DDD",
+    "ingestedPathFormat": "'WV03_MSI_L1B___1/'yyyy/DDD",
     "rule": {
       "state": "DISABLED"
     },

--- a/app/stacks/cumulus/resources/rules/WV03_MSI_L1B/v1/WV03_MSI_L1B___1_2021.json
+++ b/app/stacks/cumulus/resources/rules/WV03_MSI_L1B/v1/WV03_MSI_L1B___1_2021.json
@@ -13,6 +13,7 @@
   "meta": {
     "discoverOnly": false,
     "providerPathFormat": "'css/nga/WV03/1B/'yyyy/DDD",
+    "ingestedPathFormat": "'WV03_MSI_L1B___1/'yyyy/DDD",
     "rule": {
       "state": "DISABLED"
     },

--- a/app/stacks/cumulus/resources/rules/WV03_MSI_L1B/v1/WV03_MSI_L1B___1_2022.json
+++ b/app/stacks/cumulus/resources/rules/WV03_MSI_L1B/v1/WV03_MSI_L1B___1_2022.json
@@ -13,6 +13,7 @@
   "meta": {
     "discoverOnly": false,
     "providerPathFormat": "'css/nga/WV03/1B/'yyyy/DDD",
+    "ingestedPathFormat": "'WV03_MSI_L1B___1/'yyyy/DDD",
     "rule": {
       "state": "DISABLED"
     },

--- a/app/stacks/cumulus/resources/rules/WV03_MSI_L1B/v1/WV03_MSI_L1B___1_SmokeTest.json
+++ b/app/stacks/cumulus/resources/rules/WV03_MSI_L1B/v1/WV03_MSI_L1B___1_SmokeTest.json
@@ -13,6 +13,7 @@
   "meta": {
     "discoverOnly": false,
     "providerPathFormat": "'css/nga/WV03/1B/'yyyy/DDD",
+    "ingestedPathFormat": "'WV03_MSI_L1B___1/'yyyy/DDD",
     "rule": {
       "state": "DISABLED"
     },

--- a/app/stacks/cumulus/resources/rules/WV03_MSI_L1B/v1/WV03_MSI_L1B___1_UAT.json
+++ b/app/stacks/cumulus/resources/rules/WV03_MSI_L1B/v1/WV03_MSI_L1B___1_UAT.json
@@ -13,6 +13,7 @@
   "meta": {
     "discoverOnly": false,
     "providerPathFormat": "'css/nga/WV03/1B/'yyyy/DDD",
+    "ingestedPathFormat": "'WV03_MSI_L1B___1/'yyyy/DDD",
     "rule": {
       "state": "DISABLED"
     },

--- a/app/stacks/cumulus/resources/rules/WV04_MSI_L1B/v1/WV04_MSI_L1B___1.json
+++ b/app/stacks/cumulus/resources/rules/WV04_MSI_L1B/v1/WV04_MSI_L1B___1.json
@@ -13,6 +13,7 @@
   "meta": {
     "discoverOnly": false,
     "providerPathFormat": "'css/nga/WV04/1B/'yyyy",
+    "ingestedPathFormat": "'WV04_MSI_L1B___1/'yyyy/DDD",
     "rule": {
       "state": "DISABLED"
     },

--- a/app/stacks/cumulus/resources/rules/WV04_MSI_L1B/v1/WV04_MSI_L1B___1_SmokeTest.json
+++ b/app/stacks/cumulus/resources/rules/WV04_MSI_L1B/v1/WV04_MSI_L1B___1_SmokeTest.json
@@ -13,6 +13,7 @@
   "meta": {
     "discoverOnly": false,
     "providerPathFormat": "'css/nga/WV04/1B/'yyyy/DDD",
+    "ingestedPathFormat": "'WV04_MSI_L1B___1/'yyyy/DDD",
     "rule": {
       "state": "DISABLED"
     },

--- a/app/stacks/cumulus/templates/discover-granules-workflow.asl.json
+++ b/app/stacks/cumulus/templates/discover-granules-workflow.asl.json
@@ -27,8 +27,27 @@
       "Type": "Parallel",
       "Branches": [
         {
-          "StartAt": "FormatProviderPath",
+          "StartAt": "SelfDiscovery?",
           "States": {
+            "SelfDiscovery?": {
+              "Comment": "Are we discovering granules from our own bucket?",
+              "Type": "Choice",
+              "Choices": [
+                {
+                  "Variable": "$.meta.provider.host",
+                  "StringEqualsPath": "$.meta.buckets.protected.name",
+                  "Next": "UseIngestedPathFormat"
+                }
+              ],
+              "Default": "FormatProviderPath"
+            },
+            "UseIngestedPathFormat": {
+              "Comment": "Use the ingested path format for self-discovered granules",
+              "Type": "Pass",
+              "InputPath": "$.meta.ingestedPathFormat",
+              "ResultPath": "$.meta.providerPathFormat",
+              "Next": "FormatProviderPath"
+            },
             "FormatProviderPath": {
               "Parameters": {
                 "cma": {

--- a/app/stacks/cumulus/tfvars/uat.tfvars
+++ b/app/stacks/cumulus/tfvars/uat.tfvars
@@ -3,7 +3,7 @@
 cumulus_distribution_url = "https://9l290b9tv4.execute-api.us-west-2.amazonaws.com/dev/"
 # <% else %>
 # Trailing slash is required
-cumulus_distribution_url = "https://d7yzp0aemakw8.cloudfront.net/"
+cumulus_distribution_url = "https://data.csda.uat.earthdata.nasa.gov/"
 # <% end %>
 
 s3_replicator_target_bucket = "esdis-metrics-inbound-uat-csdap-distribution"


### PR DESCRIPTION
- Update DiscoverAndQueueGranules to recognize a new meta property named
  `"ingestedPathFormat"` and use it in place of `"providerPathFormat"`
  during "self discovery" (i.e., we are "discovering" from our own
  protected bucket)
- Add new meta `"ingestedPathFormat"` property to every rule and to the
  hygen rule template

Also:

- Add custom domain name for UAT
- Set preferredBatchQueueSize back to 5 for WV03_MSI_L1B