### PR TITLE
Throttle job queue

### DIFF
--- a/app/stacks/cumulus/main.tf
+++ b/app/stacks/cumulus/main.tf
@@ -151,7 +151,7 @@ resource "aws_cloudwatch_event_target" "background_job_queue_watcher" {
   arn  = module.cumulus.sqs2sfThrottle_lambda_function_arn
   input = jsonencode(
     {
-      messageLimit = 800
+      messageLimit = 500
       queueUrl     = aws_sqs_queue.background_job_queue.id
       timeLimit    = 60
     }
@@ -511,7 +511,7 @@ module "cumulus" {
     {
       id              = "backgroundJobQueue",
       url             = aws_sqs_queue.background_job_queue.id,
-      execution_limit = 400
+      execution_limit = 300
     }
   ]
 }

--- a/app/stacks/cumulus/resources/rules/PSScene3Band/v1/PSScene3Band___1_2015.json
+++ b/app/stacks/cumulus/resources/rules/PSScene3Band/v1/PSScene3Band___1_2015.json
@@ -12,7 +12,7 @@
   },
   "meta": {
     "providerPathFormat": "'storage-ss-ingest-prod-ingesteddata-uswest2/planet/PSScene3Band-'yyyy",
-    "ingestedPathFormat": "'planet/PSScene3Band/'yyyyMMdd_HH",
+    "ingestedPathFormat": "'planet/PSScene3Band/'yyyy",
     "startDate": "2015-01-01T00:00:00Z",
     "endDate": "2016-01-01T00:00:00Z",
     "step": "P1Y",

--- a/app/stacks/cumulus/resources/rules/PSScene3Band/v1/PSScene3Band___1_2016.json
+++ b/app/stacks/cumulus/resources/rules/PSScene3Band/v1/PSScene3Band___1_2016.json
@@ -12,7 +12,7 @@
   },
   "meta": {
     "providerPathFormat": "'storage-ss-ingest-prod-ingesteddata-uswest2/planet/PSScene3Band-'yyyyMM",
-    "ingestedPathFormat": "'planet/PSScene3Band/'yyyyMMdd_HH",
+    "ingestedPathFormat": "'planet/PSScene3Band/'yyyyMM",
     "startDate": "2016-01-01T00:00:00Z",
     "endDate": "2017-01-01T00:00:00Z",
     "step": "P1M",

--- a/app/stacks/cumulus/resources/rules/PSScene3Band/v1/PSScene3Band___1_2017.json
+++ b/app/stacks/cumulus/resources/rules/PSScene3Band/v1/PSScene3Band___1_2017.json
@@ -12,7 +12,7 @@
   },
   "meta": {
     "providerPathFormat": "'storage-ss-ingest-prod-ingesteddata-uswest2/planet/PSScene3Band-'yyyyMMdd",
-    "ingestedPathFormat": "'planet/PSScene3Band/'yyyyMMdd_HH",
+    "ingestedPathFormat": "'planet/PSScene3Band/'yyyyMMdd",
     "startDate": "2017-01-01T00:00:00Z",
     "endDate": "2018-01-01T00:00:00Z",
     "step": "P1D",

--- a/app/stacks/cumulus/resources/rules/PSScene3Band/v1/PSScene3Band___1_2018.json
+++ b/app/stacks/cumulus/resources/rules/PSScene3Band/v1/PSScene3Band___1_2018.json
@@ -12,7 +12,7 @@
   },
   "meta": {
     "providerPathFormat": "'storage-ss-ingest-prod-ingesteddata-uswest2/planet/PSScene3Band-'yyyyMMdd",
-    "ingestedPathFormat": "'planet/PSScene3Band/'yyyyMMdd_HH",
+    "ingestedPathFormat": "'planet/PSScene3Band/'yyyyMMdd",
     "startDate": "2018-01-01T00:00:00Z",
     "endDate": "2019-01-01T00:00:00Z",
     "step": "P1D",

--- a/app/stacks/cumulus/resources/rules/PSScene3Band/v1/PSScene3Band___1_2019.json
+++ b/app/stacks/cumulus/resources/rules/PSScene3Band/v1/PSScene3Band___1_2019.json
@@ -12,7 +12,7 @@
   },
   "meta": {
     "providerPathFormat": "'storage-ss-ingest-prod-ingesteddata-uswest2/planet/PSScene3Band-'yyyyMMdd",
-    "ingestedPathFormat": "'planet/PSScene3Band/'yyyyMMdd_HH",
+    "ingestedPathFormat": "'planet/PSScene3Band/'yyyyMMdd",
     "startDate": "2019-01-01T00:00:00Z",
     "endDate": "2020-01-01T00:00:00Z",
     "step": "P1D",

--- a/app/stacks/cumulus/resources/rules/PSScene3Band/v1/PSScene3Band___1_2020.json
+++ b/app/stacks/cumulus/resources/rules/PSScene3Band/v1/PSScene3Band___1_2020.json
@@ -12,7 +12,7 @@
   },
   "meta": {
     "providerPathFormat": "'storage-ss-ingest-prod-ingesteddata-uswest2/planet/PSScene3Band-'yyyyMMdd",
-    "ingestedPathFormat": "'planet/PSScene3Band/'yyyyMMdd_HH",
+    "ingestedPathFormat": "'planet/PSScene3Band/'yyyyMMdd",
     "startDate": "2020-01-01T00:00:00Z",
     "endDate": "2021-01-01T00:00:00Z",
     "step": "P1D",

--- a/app/stacks/cumulus/resources/rules/WV04_MSI_L1B/v1/WV04_MSI_L1B___1.json
+++ b/app/stacks/cumulus/resources/rules/WV04_MSI_L1B/v1/WV04_MSI_L1B___1.json
@@ -13,7 +13,7 @@
   "meta": {
     "discoverOnly": false,
     "providerPathFormat": "'css/nga/WV04/1B/'yyyy",
-    "ingestedPathFormat": "'WV04_MSI_L1B___1/'yyyy/DDD",
+    "ingestedPathFormat": "'WV04_MSI_L1B___1/'yyyy",
     "rule": {
       "state": "DISABLED"
     },


### PR DESCRIPTION
During metadata URL updates, the SyncGranule and MoveGranule steps of the IngestAndPublishGranule workflow started failing with the error "SlowDown: Please reduce your request rate." This change reduces the execution and queue limits to attempt to avoid hitting the S3 request limit.

Further, some rules had their "ingestedPathFormat" values corrected.