### PR TITLE
Retry MoveGranule and PostToCmr task failures

### DIFF
--- a/app/stacks/cumulus/templates/ingest-and-publish-granule-workflow.asl.json
+++ b/app/stacks/cumulus/templates/ingest-and-publish-granule-workflow.asl.json
@@ -84,6 +84,7 @@
                     "States.ALL"
                   ],
                   "IntervalSeconds": 2,
+                  "BackoffRate": 2,
                   "MaxAttempts": 3
                 }
               ]
@@ -172,13 +173,14 @@
               "Next": "UpdateMetadataFileLinks",
               "Retry": [
                 {
-                  "BackoffRate": 2,
                   "ErrorEquals": [
                     "Lambda.ServiceException",
                     "Lambda.AWSLambdaException",
-                    "Lambda.SdkClientException"
+                    "Lambda.SdkClientException",
+                    "States.TaskFailed"
                   ],
                   "IntervalSeconds": 2,
+                  "BackoffRate": 2,
                   "MaxAttempts": 6
                 }
               ]
@@ -218,8 +220,7 @@
                   "ErrorEquals": [
                     "Lambda.ServiceException",
                     "Lambda.AWSLambdaException",
-                    "Lambda.SdkClientException",
-                    "Error"
+                    "Lambda.SdkClientException"
                   ],
                   "IntervalSeconds": 2,
                   "MaxAttempts": 6,
@@ -252,17 +253,14 @@
                   "ErrorEquals": [
                     "Lambda.ServiceException",
                     "Lambda.AWSLambdaException",
-                    "Lambda.SdkClientException"
+                    "Lambda.SdkClientException",
+                    "States.TaskFailed"
                   ],
                   "IntervalSeconds": 2,
                   "MaxAttempts": 6,
                   "BackoffRate": 2
                 }
               ],
-              "Next": "Finish"
-            },
-            "Finish": {
-              "Type": "Pass",
               "End": true
             }
           }


### PR DESCRIPTION
Added "State.TaskFailed" retry for MoveGranule and PostToCmr tasks in the IngestAndPublishGranule workflow. The previous revision attempted this for PostToCmr, but put the entry in the wrong place.