### PR TITLE
Fix killed process for PrefixGranuleIds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ SHELL [ "/bin/bash", "-o", "pipefail", "-c" ]
 RUN : \
   && apt-get update -y \
   && apt-get install -y --no-install-recommends \
+  bc=1.07.1-3build1 \
   # Ruby requires g++ following to build gem native extensions
   g++=4:11.2.0-1ubuntu1 \
   make=4.3-4.1build1 \

--- a/src/lib/discovery.ts
+++ b/src/lib/discovery.ts
@@ -9,11 +9,10 @@ import * as L from './aws/lambda';
 import * as $t from './io';
 import { traceAsync } from './logging';
 
-const Granule = t.readonly(
-  t.type({
-    granuleId: t.string,
-  })
-);
+const Granule = t.type({
+  granuleId: t.string,
+});
+
 const GranulesPayload = t.readonly(
   t.type({
     granules: t.array(Granule),
@@ -121,12 +120,13 @@ export const prefixGranuleIds = (args: PrefixGranuleIdsInput) => {
 
   console.info(`Prefixing granuleIds for ${granules.length} granules with '${prefix}'`);
 
-  return {
-    granules: granules.map((granule: Granule) => ({
-      ...granule,
-      granuleId: `${prefix}${granule.granuleId}`,
-    })),
-  };
+  // eslint-disable-next-line functional/no-return-void
+  granules.forEach((granule: Granule) => {
+    // eslint-disable-next-line functional/immutable-data
+    granule.granuleId = `${prefix}${granule.granuleId}`;
+  });
+
+  return { granules };
 };
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION
For PSScene3Band 2020-01-18, there are over 50K granules! Normally, there are no more than 5K, and typically more like 1K-2K. I have no idea why there are over 50K for a single day, but it causes the PrefixGranuleIds lambda function to run out of memory and the process is killed. This fix avoid making a copy of the list of granules and simply modifies them in place in order to minimize required memory. Hopefully this fix is sufficient.