### PR TITLE
Allow `D` for unpadded day of year in date format

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,6 @@
     "@cumulus/common": "13.4.0",
     "@cumulus/cumulus-message-adapter-js": "2.0.4",
     "date-fns": "^2.29.3",
-    "date-fns-tz": "^1.3.7",
     "duration-fns": "^3.0.1",
     "fp-ts": "^2.11.5",
     "fp-ts-contrib": "^0.1.29",

--- a/src/lib/discovery.spec.ts
+++ b/src/lib/discovery.spec.ts
@@ -321,7 +321,7 @@ test(
   {
     config: {
       providerPathFormat: "'css/nga/WV04/1B/'yyyy/DDD",
-      startDate: '2017-05-04',
+      startDate: '2017-05-04T00:00:00Z',
     },
   },
   'css/nga/WV04/1B/2017/124'
@@ -332,8 +332,20 @@ test(
   formatProviderPath,
   {
     config: {
+      providerPathFormat: "'css/nga/WV04/1B/'yyyy/D/",
+      startDate: '2017-01-04T00:00:00Z',
+    },
+  },
+  'css/nga/WV04/1B/2017/4/'
+);
+
+test(
+  shouldOutput,
+  formatProviderPath,
+  {
+    config: {
       providerPathFormat: "'planet/PSScene3Band-'yyyyMM_dd",
-      startDate: '2018-08',
+      startDate: '2018-08-01T00:00:00Z',
     },
   },
   'planet/PSScene3Band-201808_01'
@@ -345,7 +357,7 @@ test(
   {
     config: {
       providerPathFormat: "'planet/PSScene3Band-'yyyyMM",
-      startDate: '2018-08',
+      startDate: '2018-08-01T00:00:00Z',
     },
   },
   'planet/PSScene3Band-201808'
@@ -361,7 +373,7 @@ test(
   {
     config: {
       providerPathFormat: "'planet/PSScene3Band-'yyyyMM",
-      startDate: '2018-08',
+      startDate: '2018-08-01T00:00:00Z',
     },
   },
   null
@@ -373,8 +385,8 @@ test(
   {
     config: {
       providerPathFormat: "'planet/PSScene3Band-'yyyyMM",
-      startDate: '2018-08',
-      endDate: '2021-09',
+      startDate: '2018-08-01T00:00:00Z',
+      endDate: '2021-09-01T00:00:00Z',
       step: null,
     },
   },
@@ -387,7 +399,7 @@ test(
   {
     config: {
       providerPathFormat: "'planet/PSScene3Band-'yyyyMM",
-      startDate: '2018-08',
+      startDate: '2018-08-01T00:00:00Z',
       endDate: null,
       step: 'P1M',
     },
@@ -401,8 +413,8 @@ test(
   {
     config: {
       providerPathFormat: "'planet/PSScene3Band-'yyyyMM",
-      startDate: '2018-09',
-      endDate: '2020-01',
+      startDate: '2018-09-01T00:00:00Z',
+      endDate: '2020-01-01T00:00:00Z',
       step: 'P1M',
     },
   },
@@ -415,8 +427,8 @@ test(
   {
     config: {
       providerPathFormat: "'planet/PSScene3Band-'yyyyMM",
-      startDate: '2018-08',
-      endDate: '2018-09', // endDate is exclusive
+      startDate: '2018-08-01T00:00:00Z',
+      endDate: '2018-09-01T00:00:00Z', // endDate is exclusive
       step: 'P1M',
     },
   },
@@ -429,8 +441,8 @@ test(
   {
     config: {
       providerPathFormat: "'planet/PSScene3Band-'yyyyMM",
-      startDate: '2018-08',
-      endDate: '2020-01',
+      startDate: '2018-08-01T00:00:00Z',
+      endDate: '2020-01-01T00:00:00Z',
       step: 'P1Y',
     },
   },

--- a/src/lib/discovery.ts
+++ b/src/lib/discovery.ts
@@ -1,5 +1,4 @@
 import * as dates from 'date-fns';
-import * as tz from 'date-fns-tz';
 import * as O from 'fp-ts/Option';
 import { constant, pipe } from 'fp-ts/function';
 import * as t from 'io-ts';
@@ -80,7 +79,10 @@ export type ProviderPathInput = t.TypeOf<typeof ProviderPathInput>;
  */
 export const formatProviderPath = (args: ProviderPathInput): string => {
   const { providerPathFormat, startDate } = args.config;
-  return tz.formatInTimeZone(startDate, 'Z', providerPathFormat);
+  return dates.format(startDate, providerPathFormat, {
+    useAdditionalDayOfYearTokens: true,
+    useAdditionalWeekYearTokens: true,
+  });
 };
 
 /**

--- a/src/lib/io/DateFormat.ts
+++ b/src/lib/io/DateFormat.ts
@@ -39,7 +39,10 @@ const unsafeValidatDateFormat = (s: string) => {
 
   if (s.length === 0) return false;
 
-  const options = { useAdditionalWeekYearTokens: true };
+  const options = {
+    useAdditionalWeekYearTokens: true,
+    useAdditionalDayOfYearTokens: true,
+  };
   const epoch = dates.parseISO('1970-01-01');
   const formattedEpoch = dates.formatWithOptions(options, s)(epoch);
   const parsedEpoch = dates.parseWithOptions(options, epoch, s, formattedEpoch);

--- a/yarn.lock
+++ b/yarn.lock
@@ -3547,11 +3547,6 @@ dargs@^7.0.0:
   resolved "https://registry.yarnpkg.com/dargs/-/dargs-7.0.0.tgz#04015c41de0bcb69ec84050f3d9be0caf8d6d5cc"
   integrity sha512-2iy1EkLdlBzQGvbweYRFxmFath8+K7+AKB0TlhHWkNuH+TmovaMH/Wp7V7R4u7f4SnX3OgLsU9t1NI9ioDnUpg==
 
-date-fns-tz@^1.3.7:
-  version "1.3.7"
-  resolved "https://registry.yarnpkg.com/date-fns-tz/-/date-fns-tz-1.3.7.tgz#e8e9d2aaceba5f1cc0e677631563081fdcb0e69a"
-  integrity sha512-1t1b8zyJo+UI8aR+g3iqr5fkUHWpd58VBx8J/ZSQ+w7YrGlw80Ag4sA86qkfCXRBLmMc4I2US+aPMd4uKvwj5g==
-
 date-fns@^2.29.3:
   version "2.29.3"
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.29.3.tgz#27402d2fc67eb442b511b70bbdf98e6411cd68a8"


### PR DESCRIPTION
Fixes the following error when attempting to format dates using a single `D` to represent the unpadded day of year:

```plain
RangeError: Use `d` instead of `D` (in `D`) for formatting days of the month to the input `Sat Aug 01 2020 00:00:00 GMT+0000 (Coordinated Universal Time)`; see: https://github.com/date-fns/date-fns/blob/master/docs/unicodeTokens.md
    at throwProtectedError (/work/node_modules/date-fns/_lib/protectedTokens/index.js:26:11)
    at /work/node_modules/date-fns/format/index.js:415:41
    at Array.map (<anonymous>)
    at Object.format (/work/node_modules/date-fns/format/index.js:395:45)
```