### PR TITLE
Made changes to collections for handling zero padded day of year #170

### DIFF
--- a/app/stacks/cumulus/resources/collections/WV01_Pan_L1B___1.json
+++ b/app/stacks/cumulus/resources/collections/WV01_Pan_L1B___1.json
@@ -5,7 +5,7 @@
   "granuleId": ".*",
   "granuleIdExtraction": "^(WV01_.+-P1BS-.+_P\\d{3}).+$",
   "sampleFileName": "WV01_20071231044012_1020010001E9B500_07DEC31044012-P1BS-505051421030_01_P024-BROWSE.jpg",
-  "url_path": "{cmrMetadata.CollectionReference.ShortName}___{cmrMetadata.CollectionReference.Version}/{dateFormat(cmrMetadata.TemporalExtent.SingleDateTime, YYYY)}/{dateFormat(cmrMetadata.TemporalExtent.SingleDateTime, DDD)}/{cmrMetadata.GranuleUR}",
+  "url_path": "{cmrMetadata.CollectionReference.ShortName}___{cmrMetadata.CollectionReference.Version}/{dateFormat(cmrMetadata.TemporalExtent.SingleDateTime, YYYY)}/{dateFormat(cmrMetadata.TemporalExtent.SingleDateTime, DDDD)}/{cmrMetadata.GranuleUR}",
   "meta": {
     "preferredQueueBatchSize": 5
   },

--- a/app/stacks/cumulus/resources/collections/WV02_MSI_L1B___1.json
+++ b/app/stacks/cumulus/resources/collections/WV02_MSI_L1B___1.json
@@ -5,7 +5,7 @@
   "granuleId": ".*",
   "granuleIdExtraction": "^(WV02_.+-M1BS-.+_P\\d{3}).+$",
   "sampleFileName": "WV02_20140824082814_10400100012AD900_14AUG24082814-M1BS-504548417070_01_P001-BROWSE.jpg",
-  "url_path": "{cmrMetadata.CollectionReference.ShortName}___{cmrMetadata.CollectionReference.Version}/{dateFormat(cmrMetadata.TemporalExtent.SingleDateTime, YYYY)}/{dateFormat(cmrMetadata.TemporalExtent.SingleDateTime, DDD)}/{cmrMetadata.GranuleUR}",
+  "url_path": "{cmrMetadata.CollectionReference.ShortName}___{cmrMetadata.CollectionReference.Version}/{dateFormat(cmrMetadata.TemporalExtent.SingleDateTime, YYYY)}/{dateFormat(cmrMetadata.TemporalExtent.SingleDateTime, DDDD)}/{cmrMetadata.GranuleUR}",
   "meta": {
     "preferredQueueBatchSize": 5
   },

--- a/app/stacks/cumulus/resources/collections/WV03_MSI_L1B___1.json
+++ b/app/stacks/cumulus/resources/collections/WV03_MSI_L1B___1.json
@@ -5,7 +5,7 @@
   "granuleId": ".*",
   "granuleIdExtraction": "^(WV03_.+-M1BS-.+_P\\d{3}).+(?<!rename)$",
   "sampleFileName": "WV03_20140824082814_10400100012AD900_14AUG24082814-M1BS-504548417070_01_P001-BROWSE.jpg",
-  "url_path": "{cmrMetadata.CollectionReference.ShortName}___{cmrMetadata.CollectionReference.Version}/{dateFormat(cmrMetadata.TemporalExtent.SingleDateTime, YYYY)}/{dateFormat(cmrMetadata.TemporalExtent.SingleDateTime, DDD)}/{cmrMetadata.GranuleUR}",
+  "url_path": "{cmrMetadata.CollectionReference.ShortName}___{cmrMetadata.CollectionReference.Version}/{dateFormat(cmrMetadata.TemporalExtent.SingleDateTime, YYYY)}/{dateFormat(cmrMetadata.TemporalExtent.SingleDateTime, DDDD)}/{cmrMetadata.GranuleUR}",
   "meta": {
     "preferredQueueBatchSize": 5
   },

--- a/app/stacks/cumulus/resources/collections/WV04_MSI_L1B___1.json
+++ b/app/stacks/cumulus/resources/collections/WV04_MSI_L1B___1.json
@@ -5,7 +5,7 @@
   "granuleId": ".*",
   "granuleIdExtraction": "^(WV04_.+-M1BS-.+_P\\d{3}).+(?<!rename)$",
   "sampleFileName": "WV04_20170504052256_f9ca790e-2502-46a6-9918-205faa15cd4c-inv_17MAY04052256-M1BS-059097041070_01_P001-BROWSE.jpg",
-  "url_path": "{cmrMetadata.CollectionReference.ShortName}___{cmrMetadata.CollectionReference.Version}/{dateFormat(cmrMetadata.TemporalExtent.SingleDateTime, YYYY)}/{dateFormat(cmrMetadata.TemporalExtent.SingleDateTime, DDD)}/{cmrMetadata.GranuleUR}",
+  "url_path": "{cmrMetadata.CollectionReference.ShortName}___{cmrMetadata.CollectionReference.Version}/{dateFormat(cmrMetadata.TemporalExtent.SingleDateTime, YYYY)}/{dateFormat(cmrMetadata.TemporalExtent.SingleDateTime, DDDD)}/{cmrMetadata.GranuleUR}",
   "meta": {
     "preferredQueueBatchSize": 5
   },

--- a/app/stacks/cumulus/resources/collections/WV04_Pan_L1B___1.json
+++ b/app/stacks/cumulus/resources/collections/WV04_Pan_L1B___1.json
@@ -5,7 +5,7 @@
   "granuleId": ".*",
   "granuleIdExtraction": "^(WV04_.+-P1BS-.+_P\\d{3}).+$",
   "sampleFileName": "WV04_20170505053805_594e4035-a94b-4da5-a5a2-9593702d7739-inv_17MAY05053805-P1BS-059102583030_01_P001-BROWSE.jpg",
-  "url_path": "{cmrMetadata.CollectionReference.ShortName}___{cmrMetadata.CollectionReference.Version}/{dateFormat(cmrMetadata.TemporalExtent.SingleDateTime, YYYY)}/{dateFormat(cmrMetadata.TemporalExtent.SingleDateTime, DDD)}/{cmrMetadata.GranuleUR}",
+  "url_path": "{cmrMetadata.CollectionReference.ShortName}___{cmrMetadata.CollectionReference.Version}/{dateFormat(cmrMetadata.TemporalExtent.SingleDateTime, YYYY)}/{dateFormat(cmrMetadata.TemporalExtent.SingleDateTime, DDDD)}/{cmrMetadata.GranuleUR}",
   "meta": {
     "preferredQueueBatchSize": 5
   },


### PR DESCRIPTION
This PR is to fix a bug in the collections configuration where we were not handling zero padded day of year.

This is also in conjunction with the CMR updates ran on ticket #170 
https://github.com/NASA-IMPACT/csdap-cumulus/issues/170
