### PR TITLE
Had to increase the date range to get enough granules. 

### DIFF
--- a/app/stacks/cumulus/resources/rules/WV02_MSI_L1B/v1/WV02_MSI_L1B___1_UAT.json
+++ b/app/stacks/cumulus/resources/rules/WV02_MSI_L1B/v1/WV02_MSI_L1B___1_UAT.json
@@ -17,7 +17,7 @@
     "rule": {
       "state": "DISABLED"
     },
-    "startDate": "2009-12-26T00:00:00Z",
+    "startDate": "2009-12-16T00:00:00Z",
     "endDate": "2009-12-27T00:00:00Z",
     "step": "P1D"
   }


### PR DESCRIPTION
 Not all of the ones in the initial rule had matching entries in the DynamoDB so some were skipped #101