### PR TITLE
Fix for too many PrefixGranuleIds in a single day.

### DIFF
--- a/app/stacks/cumulus/main.tf
+++ b/app/stacks/cumulus/main.tf
@@ -14,7 +14,7 @@ locals {
   dynamo_tables = jsondecode("<%= json_output('data-persistence.dynamo_tables') %>")
 
   ecs_task_cpu                = 768
-  ecs_task_image              = "cumuluss/cumulus-ecs-task:1.8.0"
+  ecs_task_image              = "cumuluss/cumulus-ecs-task:1.9.1"
   ecs_task_memory_reservation = 3277
 
   elasticsearch_alarms            = jsondecode("<%= json_output('data-persistence.elasticsearch_alarms') %>")

--- a/app/stacks/cumulus/resources/rules/PSScene3Band/v1/PSScene3Band___1_2020_finish_link_updates.json
+++ b/app/stacks/cumulus/resources/rules/PSScene3Band/v1/PSScene3Band___1_2020_finish_link_updates.json
@@ -1,0 +1,23 @@
+{
+  "name": "PSScene3Band___1_2020_finish_link_updates",
+  "state": "DISABLED",
+  "provider": "planet",
+  "collection": {
+    "name": "PSScene3Band",
+    "version": "1"
+  },
+  "workflow": "DiscoverAndQueueGranules",
+  "rule": {
+    "type": "onetime"
+  },
+  "meta": {
+    "providerPathFormat": "'storage-ss-ingest-prod-ingesteddata-uswest2/planet/PSScene3Band-'yyyyMMdd",
+    "ingestedPathFormat": "'planet/PSScene3Band/'yyyyMMdd",
+    "startDate": "2020-01-18T00:00:00Z",
+    "endDate": "2021-01-01T00:00:00Z",
+    "step": "P1D",
+    "rule": {
+      "state": "DISABLED"
+    }
+  }
+}


### PR DESCRIPTION
Fixed a bug where the Lambda could not handle too many Granules in a single day for the PrefixGranuleIds step.
Now an ECS Task spins up for this process.
Also updated the cumulus-ecs-task source to address a previous bug where ECS tasks with too many zipped files could not be properly extracted and spun up.
Through this process, we defined a new resource and module for Terraform to deploy.
Also included here is the rule file for #180 which allows us to continue the CMR updates ingest for PSScene after this bug fix is applied.

Related Tickets
#180  and #222 