### PR TITLE
Disable S3Credentials endpoint for all future deployments of Cumulus

### DIFF
--- a/app/stacks/cumulus/main.tf
+++ b/app/stacks/cumulus/main.tf
@@ -496,6 +496,8 @@ module "cumulus_distribution" {
   deploy_to_ngap            = true
   lambda_subnet_ids         = module.vpc.subnets.ids
 
+  deploy_s3_credentials_endpoint = false
+
   oauth_client_id       = data.aws_ssm_parameter.csdap_client_id.value
   oauth_client_password = data.aws_ssm_parameter.csdap_client_password.value
   oauth_host_url        = var.csdap_host_url


### PR DESCRIPTION
Disable S3Credentials endpoint for all future deployments of Cumulus until this setting needs to be adjusted again #245
![Screenshot 2023-09-06 at 4 38 32 PM](https://github.com/NASA-IMPACT/csdap-cumulus/assets/57300896/750ec985-9dab-4037-88e6-41f2004d7bed)
