### PR TITLE
Fix SNS topic subscribe permissions

### DIFF
--- a/app/stacks/cumulus/templates/discover-granules-workflow.asl.json
+++ b/app/stacks/cumulus/templates/discover-granules-workflow.asl.json
@@ -90,7 +90,7 @@
                           "buckets": "{$.meta.buckets}",
                           "stack": "{$.meta.stack}",
                           "duplicateGranuleHandling": "{$.meta.collection.duplicateHandling}",
-                          "concurrency": 8
+                          "concurrency": 4
                         }
                       }
                     },


### PR DESCRIPTION
The permissions on our SNS topics to allow the Metrics team to subscribe to them was configured in a non-deterministic way, which meant that it was possible for the permissions not to be applied. This is precisely what happened in CBA Prod.

This fix makes things deterministic, so deployment will always end up with the required permissions on the SNS topics to allow Metrics to subscribe to the topics.