### PR TITLE
Increase RDS connection pool max capacity in Prod

### DIFF
--- a/app/stacks/cumulus/main.tf
+++ b/app/stacks/cumulus/main.tf
@@ -161,9 +161,9 @@ resource "aws_cloudwatch_event_target" "background_job_queue_watcher" {
   arn  = module.cumulus.sqs2sfThrottle_lambda_function_arn
   input = jsonencode(
     {
-      messageLimit = 1000
+      messageLimit = 300
       queueUrl     = aws_sqs_queue.background_job_queue.id
-      timeLimit    = 60
+      timeLimit    = 30
     }
   )
 }
@@ -576,7 +576,7 @@ module "cumulus" {
     {
       id              = "backgroundJobQueue",
       url             = aws_sqs_queue.background_job_queue.id,
-      execution_limit = 300
+      execution_limit = 500
     }
   ]
 }

--- a/app/stacks/cumulus/resources/collections/WV03_MSI_L1B___1.json
+++ b/app/stacks/cumulus/resources/collections/WV03_MSI_L1B___1.json
@@ -1,7 +1,7 @@
 {
   "name": "WV03_MSI_L1B",
   "version": "1",
-  "duplicateHandling": "replace",
+  "duplicateHandling": "skip",
   "granuleId": ".*",
   "granuleIdExtraction": "^(WV03_.+-M1BS-.+_P\\d{3}).+(?<!rename)$",
   "sampleFileName": "WV03_20140824082814_10400100012AD900_14AUG24082814-M1BS-504548417070_01_P001-BROWSE.jpg",

--- a/app/stacks/cumulus/resources/collections/WV03_Pan_L1B___1.json
+++ b/app/stacks/cumulus/resources/collections/WV03_Pan_L1B___1.json
@@ -1,7 +1,7 @@
 {
   "name": "WV03_Pan_L1B",
   "version": "1",
-  "duplicateHandling": "replace",
+  "duplicateHandling": "skip",
   "granuleId": ".*",
   "granuleIdExtraction": "^(WV03_.+-P1BS-.+_P\\d{3}).+(?<!rename)$",
   "sampleFileName": "WV03_20140824052550_104001000109D200_14AUG24052550-P1BS-506481065090_01_P001-BROWSE.jpg",

--- a/app/stacks/cumulus/templates/discover-granules-workflow.asl.json
+++ b/app/stacks/cumulus/templates/discover-granules-workflow.asl.json
@@ -30,8 +30,8 @@
     "DiscoverGranulesMap": {
       "Type": "Map",
       "End": true,
-      "MaxConcurrency": 3,
-      "ToleratedFailurePercentage": 3,
+      "MaxConcurrency": 7,
+      "ToleratedFailurePercentage": 1,
       "ItemReader": {
         "Resource": "arn:aws:states:::s3:getObject",
         "ReaderConfig": {
@@ -102,7 +102,8 @@
                           "Lambda.ClientExecutionTimeoutException",
                           "Lambda.ServiceException",
                           "Lambda.AWSLambdaException",
-                          "Lambda.SdkClientException"
+                          "Lambda.SdkClientException",
+                          "Lambda.TooManyRequestsException"
                         ],
                         "IntervalSeconds": 2,
                         "MaxAttempts": 6,
@@ -144,7 +145,8 @@
                           "Lambda.ClientExecutionTimeoutException",
                           "Lambda.ServiceException",
                           "Lambda.AWSLambdaException",
-                          "Lambda.SdkClientException"
+                          "Lambda.SdkClientException",
+                          "Lambda.TooManyRequestsException"
                         ],
                         "IntervalSeconds": 2,
                         "MaxAttempts": 6,
@@ -155,7 +157,7 @@
                   },
                   "QueueGranulesMap": {
                     "Type": "Map",
-                    "MaxConcurrency": 1,
+                    "MaxConcurrency": 2,
                     "ToleratedFailurePercentage": 0,
                     "ItemsPath": "$",
                     "ResultWriter": {
@@ -195,7 +197,8 @@
                                 "Lambda.ClientExecutionTimeoutException",
                                 "Lambda.ServiceException",
                                 "Lambda.AWSLambdaException",
-                                "Lambda.SdkClientException"
+                                "Lambda.SdkClientException",
+                                "Lambda.TooManyRequestsException"
                               ],
                               "IntervalSeconds": 2,
                               "MaxAttempts": 6,
@@ -245,7 +248,8 @@
                                 "Lambda.ClientExecutionTimeoutException",
                                 "Lambda.ServiceException",
                                 "Lambda.AWSLambdaException",
-                                "Lambda.SdkClientException"
+                                "Lambda.SdkClientException",
+                                "Lambda.TooManyRequestsException"
                               ],
                               "IntervalSeconds": 2,
                               "MaxAttempts": 6,
@@ -287,7 +291,7 @@
                                 "TargetPath": "$.payload"
                               },
                               "task_config": {
-                                "concurrency": 2,
+                                "concurrency": 4,
                                 "queueUrl": "${background_job_queue_url}",
                                 "preferredQueueBatchSize": "{$.meta.collection.meta.preferredQueueBatchSize}",
                                 "provider": "{$.meta.provider}",
@@ -303,14 +307,27 @@
                           "Resource": "${queue_granules_task_arn}",
                           "Retry": [
                             {
+                              "Comment": "Include 'Error' because Cumulus fails to rethrow Knex errors as something more specific.",
                               "ErrorEquals": [
+                                "Error",
                                 "Lambda.ClientExecutionTimeoutException",
                                 "Lambda.ServiceException",
                                 "Lambda.AWSLambdaException",
-                                "Lambda.SdkClientException"
+                                "Lambda.SdkClientException",
+                                "Lambda.TooManyRequestsException"
                               ],
                               "IntervalSeconds": 2,
                               "MaxAttempts": 6,
+                              "BackoffRate": 2
+                            },
+                            {
+                              "Comment": "When approaching a timeout, the CMA causes early termination, thus preventing an actual timeout, which produces 'Lambda.Unknown' errors instead.  In these cases, we don't want as many retries, and we want to space them further apart.",
+                              "ErrorEquals": [
+                                "Lambda.Unknown",
+                                "States.Timeout"
+                              ],
+                              "IntervalSeconds": 120,
+                              "MaxAttempts": 4,
                               "BackoffRate": 2
                             }
                           ]

--- a/app/stacks/cumulus/templates/ingest-and-publish-granule-workflow.asl.json
+++ b/app/stacks/cumulus/templates/ingest-and-publish-granule-workflow.asl.json
@@ -36,7 +36,21 @@
                   }
                 }
               },
-              "Next": "SyncGranule"
+              "Next": "SyncGranule",
+              "Retry": [
+                {
+                  "ErrorEquals": [
+                    "Lambda.ClientExecutionTimeoutException",
+                    "Lambda.ServiceException",
+                    "Lambda.AWSLambdaException",
+                    "Lambda.SdkClientException",
+                    "Lambda.TooManyRequestsException"
+                  ],
+                  "IntervalSeconds": 2,
+                  "MaxAttempts": 6,
+                  "BackoffRate": 2
+                }
+              ]
             },
             "SyncGranule": {
               "Parameters": {
@@ -81,6 +95,18 @@
               "Retry": [
                 {
                   "ErrorEquals": [
+                    "Lambda.ClientExecutionTimeoutException",
+                    "Lambda.ServiceException",
+                    "Lambda.AWSLambdaException",
+                    "Lambda.SdkClientException",
+                    "Lambda.TooManyRequestsException"
+                  ],
+                  "IntervalSeconds": 2,
+                  "MaxAttempts": 6,
+                  "BackoffRate": 2
+                },
+                {
+                  "ErrorEquals": [
                     "States.ALL"
                   ],
                   "IntervalSeconds": 2,
@@ -117,7 +143,29 @@
                   }
                 }
               },
-              "Next": "AddMissingFileChecksums"
+              "Next": "AddMissingFileChecksums",
+              "Retry": [
+                {
+                  "ErrorEquals": [
+                    "Lambda.ClientExecutionTimeoutException",
+                    "Lambda.ServiceException",
+                    "Lambda.AWSLambdaException",
+                    "Lambda.SdkClientException",
+                    "Lambda.TooManyRequestsException"
+                  ],
+                  "IntervalSeconds": 2,
+                  "MaxAttempts": 6,
+                  "BackoffRate": 2
+                },
+                {
+                  "ErrorEquals": [
+                    "States.ALL"
+                  ],
+                  "IntervalSeconds": 2,
+                  "BackoffRate": 2,
+                  "MaxAttempts": 3
+                }
+              ]
             },
             "AddMissingFileChecksums": {
               "Type": "Task",
@@ -148,7 +196,29 @@
                   }
                 }
               },
-              "Next": "MoveGranule"
+              "Next": "MoveGranule",
+              "Retry": [
+                {
+                  "ErrorEquals": [
+                    "Lambda.ClientExecutionTimeoutException",
+                    "Lambda.ServiceException",
+                    "Lambda.AWSLambdaException",
+                    "Lambda.SdkClientException",
+                    "Lambda.TooManyRequestsException"
+                  ],
+                  "IntervalSeconds": 2,
+                  "MaxAttempts": 6,
+                  "BackoffRate": 2
+                },
+                {
+                  "ErrorEquals": [
+                    "States.ALL"
+                  ],
+                  "IntervalSeconds": 2,
+                  "BackoffRate": 2,
+                  "MaxAttempts": 3
+                }
+              ]
             },
             "MoveGranule": {
               "Parameters": {
@@ -174,14 +244,23 @@
               "Retry": [
                 {
                   "ErrorEquals": [
+                    "Lambda.ClientExecutionTimeoutException",
                     "Lambda.ServiceException",
                     "Lambda.AWSLambdaException",
                     "Lambda.SdkClientException",
-                    "States.TaskFailed"
+                    "Lambda.TooManyRequestsException"
+                  ],
+                  "IntervalSeconds": 2,
+                  "MaxAttempts": 6,
+                  "BackoffRate": 2
+                },
+                {
+                  "ErrorEquals": [
+                    "States.ALL"
                   ],
                   "IntervalSeconds": 2,
                   "BackoffRate": 2,
-                  "MaxAttempts": 6
+                  "MaxAttempts": 3
                 }
               ]
             },
@@ -218,13 +297,23 @@
               "Retry": [
                 {
                   "ErrorEquals": [
+                    "Lambda.ClientExecutionTimeoutException",
                     "Lambda.ServiceException",
                     "Lambda.AWSLambdaException",
-                    "Lambda.SdkClientException"
+                    "Lambda.SdkClientException",
+                    "Lambda.TooManyRequestsException"
                   ],
                   "IntervalSeconds": 2,
                   "MaxAttempts": 6,
                   "BackoffRate": 2
+                },
+                {
+                  "ErrorEquals": [
+                    "States.ALL"
+                  ],
+                  "IntervalSeconds": 2,
+                  "BackoffRate": 2,
+                  "MaxAttempts": 3
                 }
               ]
             },
@@ -246,20 +335,29 @@
               },
               "Type": "Task",
               "Resource": "${copy_to_archive_adapter_task_arn}",
+              "Next": "PostToCmr",
               "Retry": [
                 {
                   "ErrorEquals": [
+                    "Lambda.ClientExecutionTimeoutException",
                     "Lambda.ServiceException",
                     "Lambda.AWSLambdaException",
                     "Lambda.SdkClientException",
-                    "States.TaskFailed"
+                    "Lambda.TooManyRequestsException"
                   ],
                   "IntervalSeconds": 2,
                   "MaxAttempts": 6,
                   "BackoffRate": 2
+                },
+                {
+                  "ErrorEquals": [
+                    "States.ALL"
+                  ],
+                  "IntervalSeconds": 2,
+                  "BackoffRate": 2,
+                  "MaxAttempts": 3
                 }
-              ],
-              "Next": "PostToCmr"
+              ]
             },
             "PostToCmr": {
               "Parameters": {
@@ -284,14 +382,23 @@
               "Retry": [
                 {
                   "ErrorEquals": [
+                    "Lambda.ClientExecutionTimeoutException",
                     "Lambda.ServiceException",
                     "Lambda.AWSLambdaException",
                     "Lambda.SdkClientException",
-                    "States.TaskFailed"
+                    "Lambda.TooManyRequestsException"
                   ],
                   "IntervalSeconds": 2,
                   "MaxAttempts": 6,
                   "BackoffRate": 2
+                },
+                {
+                  "ErrorEquals": [
+                    "States.ALL"
+                  ],
+                  "IntervalSeconds": 2,
+                  "BackoffRate": 2,
+                  "MaxAttempts": 3
                 }
               ],
               "End": true

--- a/app/stacks/rds-cluster/main.tf
+++ b/app/stacks/rds-cluster/main.tf
@@ -28,6 +28,8 @@ module "rds_cluster" {
   permissions_boundary_arn = local.permissions_boundary_arn
   prefix                   = var.prefix
   provision_user_database  = true
+  min_capacity             = var.min_capacity
+  max_capacity             = var.max_capacity
   # ORCA requires us to use a password that contains a special character, but there is
   # some Cumulus constraint that allows only an underscore (in addition to alphanumeric
   # characters), and no other special characters, so we must generate a password that

--- a/app/stacks/rds-cluster/tfvars/prod.tfvars
+++ b/app/stacks/rds-cluster/tfvars/prod.tfvars
@@ -1,0 +1,4 @@
+# See https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/rds_cluster
+
+min_capacity = 2
+max_capacity = 384

--- a/app/stacks/rds-cluster/variables.tf
+++ b/app/stacks/rds-cluster/variables.tf
@@ -1,0 +1,9 @@
+variable "max_capacity" {
+  type    = number
+  default = 4
+}
+
+variable "min_capacity" {
+  type    = number
+  default = 2
+}

--- a/src/lib/discovery.ts
+++ b/src/lib/discovery.ts
@@ -61,13 +61,13 @@ type BucketKey = {
   readonly key: string;
 };
 
-// Default maximum batch size for batching granules after discovery is 5000, but this
+// Default maximum batch size for batching granules after discovery is 1000, but this
 // can be set on a per rule basis by setting `meta.maxBatchSize` in a rule definition.
 export const BatchGranulesInput = t.readonly(
   t.type({
     config: t.type({
       providerPath: t.string,
-      maxBatchSize: tt.fromNullable(t.number, 5000),
+      maxBatchSize: tt.fromNullable(t.number, 1000),
     }),
     input: DiscoverGranulesOutput,
   })


### PR DESCRIPTION
Also:

- increase step function state concurrency, which the increased connection pool capacity should now handle
- add missing retry configuration for steps in ingestion workflow to increase resilience
- set duplicateHandling to "skip" for both WV03 collections to allow rerunning ingestion without reingesting existing granules
- reduce background queue message limit to avoid reaching concurrency quota for Lambda executions
- increase queue throttle to increase ingestion rate (in combination with previous point, this should still keep us within Lamba quota)
- reduce default granule batch size for queuing to 1000 to ensure we won't encounter QueueGranules timeouts with "skip" duplicate handling (due to extra DB queries by DiscoverGranules to check for duplicates)