### PR TITLE
Quick Fixes for recent changes

### DIFF
--- a/.github/workflows/terraspace.yml
+++ b/.github/workflows/terraspace.yml
@@ -102,6 +102,10 @@ jobs:
         run: |
           yarn --non-interactive install
 
+      - name: Run Post Deploy Mods setup
+        run: |
+          sh app/stacks/post-deploy-mods/resources/lambdas/pre-filter-DistributionApiEndpoints/zip_lambda.sh
+
       - name: Plan Cumulus
         if: ${{ !inputs.deploy }}
         run: |

--- a/app/stacks/post-deploy-mods/main.tf
+++ b/app/stacks/post-deploy-mods/main.tf
@@ -6,7 +6,7 @@ resource "aws_lambda_function" "pre_filter_DistApiEndpoints" {
   function_name = "${var.prefix}-pre-filter-DistApiEndpoints"
   filename      = "${path.module}/resources/lambdas/pre-filter-DistributionApiEndpoints/distro/lambda.zip"
   role          = aws_iam_role.lambda_exec_pre_filter_DistApiEndpoints.arn
-  handler       = "index.preFilterDistApiEndpoints"
+  handler       = "lambda_function.lambda_handler" #"index.preFilterDistApiEndpoints"
   runtime       = "python3.10" #local.lambda_runtime
   timeout       = 300
   memory_size   = 3008
@@ -37,6 +37,10 @@ resource "aws_iam_role" "lambda_exec_pre_filter_DistApiEndpoints" {
       },
     ]
   })
+
+  #  lifecycle {
+  #    prevent_destroy = true
+  #  }
 }
 
 # Define an attachment to the aws_iam_role above
@@ -68,6 +72,12 @@ resource "aws_iam_policy" "lambda_invoke_policy" {
 resource "aws_iam_role_policy_attachment" "lambda_invoke_policy_attachment" {
   role        = aws_iam_role.lambda_exec_pre_filter_DistApiEndpoints.name
   policy_arn  = aws_iam_policy.lambda_invoke_policy.arn
+}
+
+# Attach an AWS managed Policy for DynamoDB Read Only access
+resource "aws_iam_role_policy_attachment" "dynamodb_readonly_policy" {
+  role        = aws_iam_role.lambda_exec_pre_filter_DistApiEndpoints.name
+  policy_arn  = "arn:aws:iam::aws:policy/AmazonDynamoDBReadOnlyAccess"
 }
 
 # Fetch existing API Gateway
@@ -121,4 +131,19 @@ resource "aws_lambda_permission" "api_gateway" {
   function_name = aws_lambda_function.pre_filter_DistApiEndpoints.function_name
   principal = "apigateway.amazonaws.com"
   source_arn = "${data.aws_api_gateway_rest_api.distribution_api.execution_arn}/*/*"
+}
+
+# Ensure the API Gateway redeploys after the update
+resource "aws_api_gateway_deployment" "api_deployment" {
+  depends_on = [aws_api_gateway_integration.proxy_lambda_integration]
+
+  rest_api_id = data.aws_api_gateway_rest_api.distribution_api.id
+  stage_name = "dev"  # The existing cumulus deployment for this API Gateway Stage is always called dev (in all environments)
+
+  triggers = {
+    redeployment = sha1(jsonencode({
+      lambda_version = aws_lambda_function.pre_filter_DistApiEndpoints.source_code_hash
+      integration_uri = aws_api_gateway_integration.proxy_lambda_integration.uri
+    }))
+  }
 }

--- a/app/stacks/post-deploy-mods/resources/lambdas/pre-filter-DistributionApiEndpoints/src/lambda_function.py
+++ b/app/stacks/post-deploy-mods/resources/lambdas/pre-filter-DistributionApiEndpoints/src/lambda_function.py
@@ -7,6 +7,7 @@ import sys
 # To call another lambda, from this lambda
 import boto3
 
+# This Value should represent the Cumulus Prefix: ENV_VAR__CUMULUS_PREFIX
 
 # SETTINGS
 #

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -10,7 +10,8 @@
     "clean:all": "yarn clean:build && yarn clean:dependencies",
     "generate-test-granule-files": "yarn build && cd .. && node scripts/build/generate-test-granule-files.js",
     "rerun-step-function": "yarn build && cd .. && node scripts/build/rerun-step-function.js",
-    "terraform-doctor": "yarn build && cd .. && node scripts/build/terraform-doctor.js"
+    "terraform-doctor": "yarn build && cd .. && node scripts/build/terraform-doctor.js",
+    "post-deploy-mods": "sh app/stacks/post-deploy-mods/resources/lambdas/pre-filter-DistributionApiEndpoints/zip_lambda.sh"
   },
   "devDependencies": {
     "@types/uuid": "^9.0.7",

--- a/scripts/src/post-deploy-mods.sh
+++ b/scripts/src/post-deploy-mods.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+echo ""
+echo "post-deploy-mods.sh: STARTED"
+
+# About to call zip lambdas
+ZIP_LAMBDAS_PATH="app/stacks/post-deploy-mods/resources/lambdas/pre-filter-DistributionApiEndpoints/zip_lambda.sh"
+echo "post-deploy-mods.sh: About to call zip_lambda.sh at path: $ZIP_LAMBDAS_PATH"
+sh "$ZIP_LAMBDAS_PATH"
+
+echo "post-deploy-mods.sh: ENDED"
+echo ""


### PR DESCRIPTION
Quick Fixes for recent changes

Add a line in the terraspace deployment script to call to zip_lambdas.sh.    
Ensure the API Gateway will redeploy (API Gateway deployment, not the main application deployment).    
Ensure the lambda execution role for the new lambda can actually call DynamoDB with ReadOnly Access.  
Added an extra line in the Lambda to verify the environment variable makes it through the deployment process.  
Added a call to the zip lambdas function for local deployment.  

Ticket Reference: https://github.com/NASA-IMPACT/csda-project/issues/655

Note: The nature of the environment that these changes affect is only in UAT and PROD, so I need to push this to UAT to do the actual feature / fix testing.

Note: The smoke test passed in sandbox and I verified the new AWS Components were properly setup in Sandbox.  I cannot do the integrated test until this is in UAT though (because there is no sandbox set up for the cross account cognito layer access token that this work depends on)