### PR TITLE
chore: local dev setup fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -190,5 +190,5 @@ validate-%: docker
 
 ## Zip any lambda functions to prepare for deployment
 zip_lambdas:
-	export DOTENV=$(DOTENV) && \
+	DOTENV=$(DOTENV) \
 	sh app/stacks/post-deploy-mods/resources/lambdas/pre-filter-DistributionApiEndpoints/zip_lambda.sh

--- a/Makefile
+++ b/Makefile
@@ -190,4 +190,5 @@ validate-%: docker
 
 ## Zip any lambda functions to prepare for deployment
 zip_lambdas:
+	export DOTENV=$(DOTENV) && \
 	sh app/stacks/post-deploy-mods/resources/lambdas/pre-filter-DistributionApiEndpoints/zip_lambda.sh

--- a/Makefile
+++ b/Makefile
@@ -155,7 +155,7 @@ plan-%: install
 ## pre-deploy-setup: Setup resources prior to initial deployment (idempotent)
 pre-deploy-setup: all-init
 	# Ensure buckets exist, grab the name of the "internal" bucket, and copy launchpad.pfx there.
-	$(DOCKER_RUN) --interactive $(IMAGE) -ic "bin/ensure-buckets-exist.sh 2>/dev/null
+	$(DOCKER_RUN) --interactive $(IMAGE) -ic "bin/ensure-buckets-exist.sh 2>/dev/null"
 
 ## terraform-doctor-STACK: Fixes "duplicate resource" errors for specified STACK
 terraform-doctor-%: docker

--- a/bin/create-test-data.sh
+++ b/bin/create-test-data.sh
@@ -10,7 +10,8 @@ echo -n "Determining provider bucket..."
 provider_bucket="$(
   echo 'var.buckets["provider"]["name"]' |
     terraspace console cumulus 2>/dev/null |
-    grep "${CUMULUS_PREFIX}"
+    grep "${CUMULUS_PREFIX}" |
+    sed -E 's/"(.+)"/\1/'
 )"
 echo "${provider_bucket}"
 


### PR DESCRIPTION
## What I am changing

I recently spun up a Cumulus instance in the CBA sandbox account to help test the [CNM work](https://github.com/NASA-IMPACT/csda-project/issues/798) and encountered a couple hiccups on a fresh install (nothing Cumulus-related on my machine before this).

This branch is mostly fixing typos + populating env vars for local dev — no functional changes to live code.

## How I did it

- Source `$DOTENV` in `zip_lambda` shell
- Close double quotes on `pre-deploy-setup` target
- Trim TF syntax on console output piped to script
- Run `terraspace fmt` on post-deploy-mods/main.tf (blocking commit on unrelated files)

## How you can test it

The following commands should run successfully
```sh
$ make pre-deploy-setup
# also verifies the zip_lambda target

$  make create-test-data
```