### PR TITLE
Enable CNM-driven Ingestion

### DIFF
--- a/_templates/cnm-rule/new/cnm-rule.ejs.t
+++ b/_templates/cnm-rule/new/cnm-rule.ejs.t
@@ -1,0 +1,27 @@
+---
+to: "app/stacks/cumulus/resources/rules/<%= collectionName %>/v<%= collectionVersion %>/<%= collectionName %>___<%= collectionVersion %>_CNM.json"
+message: >
+  hygen cnm-rule new
+  --provider <%= provider %>
+  --collection-name <%= collectionName %>
+  --collection-version <%= collectionVersion %>
+---
+{
+  "name": "<%= collectionName %>___<%= collectionVersion %>_CNM",
+  "state": "ENABLED",
+  "workflow": "CNMIngestAndPublishGranule",
+  "provider": "<%= provider %>",
+  "collection": {
+    "name": "<%= collectionName %>",
+    "version": "<%= collectionVersion %>"
+  },
+  "rule": {
+    "type": "sns"
+  },
+  "meta": {
+    "cnmResponseMethod": "sns"
+  },
+  "tags": [
+    "cnm"
+  ]
+}

--- a/_templates/cnm-rule/new/prompt.js
+++ b/_templates/cnm-rule/new/prompt.js
@@ -1,0 +1,20 @@
+// see types of prompts:
+// https://github.com/enquirer/enquirer/tree/master/examples
+//
+module.exports = [
+  {
+    type: 'input',
+    name: 'provider',
+    message: "Provider ID (example: maxar):"
+  },
+  {
+    type: 'input',
+    name: 'collectionName',
+    message: "Collection name (example: WV03_MSI_L1B):"
+  },
+  {
+    type: 'input',
+    name: 'collectionVersion',
+    message: "Collection version (example: 1):"
+  }
+]

--- a/app/stacks/cumulus/config/hooks/terraform.rb
+++ b/app/stacks/cumulus/config/hooks/terraform.rb
@@ -24,6 +24,7 @@ class PatchCumulus18_1_0
       "cumulus/tf-modules/ingest/message_template.tf",
       "discover_granules_workflow/tf-modules/workflow/main.tf",
       "ingest_and_publish_granule_workflow/tf-modules/workflow/main.tf",
+      "cnm_ingest_and_publish_granule_workflow/tf-modules/workflow/main.tf",
     ]
 
     filepaths.each do |filepath|

--- a/app/stacks/cumulus/main.tf
+++ b/app/stacks/cumulus/main.tf
@@ -580,8 +580,6 @@ module "ingest_and_publish_granule_workflow" {
     sync_granule_task_arn : module.cumulus.sync_granule_task.task_arn,
     add_ummg_checksums_task_arn : aws_lambda_function.add_ummg_checksums.arn,
     add_missing_file_checksums_task_arn : module.cumulus.add_missing_file_checksums_task.task_arn,
-    fake_processing_task_arn : module.cumulus.fake_processing_task.task_arn,
-    files_to_granules_task_arn : module.cumulus.files_to_granules_task.task_arn,
     move_granules_task_arn : module.cumulus.move_granules_task.task_arn,
     update_granules_cmr_metadata_file_links_task_arn : module.cumulus.update_granules_cmr_metadata_file_links_task.task_arn,
     copy_to_archive_adapter_task_arn : module.cumulus.orca_copy_to_archive_adapter_task.task_arn,

--- a/app/stacks/cumulus/resources/rules/WV04_MSI_L1B/v1/WV04_MSI_L1B___1_CNM.json
+++ b/app/stacks/cumulus/resources/rules/WV04_MSI_L1B/v1/WV04_MSI_L1B___1_CNM.json
@@ -1,0 +1,19 @@
+{
+  "name": "WV04_MSI_L1B___1_CNM",
+  "state": "ENABLED",
+  "workflow": "CNMIngestAndPublishGranule",
+  "provider": "cumulus",
+  "collection": {
+    "name": "WV04_MSI_L1B",
+    "version": "1"
+  },
+  "rule": {
+    "type": "sns"
+  },
+  "meta": {
+    "cnmResponseMethod": "sns"
+  },
+  "tags": [
+    "cnm"
+  ]
+}

--- a/app/stacks/cumulus/resources/rules/WV04_Pan_L1B/v1/WV04_Pan_L1B___1_CNM.json
+++ b/app/stacks/cumulus/resources/rules/WV04_Pan_L1B/v1/WV04_Pan_L1B___1_CNM.json
@@ -1,0 +1,19 @@
+{
+  "name": "WV04_Pan_L1B___1_CNM",
+  "state": "ENABLED",
+  "workflow": "CNMIngestAndPublishGranule",
+  "provider": "cumulus",
+  "collection": {
+    "name": "WV04_Pan_L1B",
+    "version": "1"
+  },
+  "rule": {
+    "type": "sns"
+  },
+  "meta": {
+    "cnmResponseMethod": "sns"
+  },
+  "tags": [
+    "cnm"
+  ]
+}

--- a/app/stacks/cumulus/ssm_parameters.tf
+++ b/app/stacks/cumulus/ssm_parameters.tf
@@ -81,6 +81,12 @@ data "aws_ssm_parameter" "orca_s3_secret_key" {
   name = "/shared/cumulus/orca/dr/s3-secret-key"
 }
 
+# MCP Account ID
+
+data "aws_ssm_parameter" "mcp_account_id" {
+  name = "/shared/cumulus/mcp-account-id"
+}
+
 #-------------------------------------------------------------------------------
 # SSM Parameters required across ONLY non-sandbox (non-dev) environments
 #-------------------------------------------------------------------------------

--- a/app/stacks/cumulus/templates/cnm-ingest-and-publish-granule-workflow.asl.json
+++ b/app/stacks/cumulus/templates/cnm-ingest-and-publish-granule-workflow.asl.json
@@ -1,0 +1,685 @@
+{
+  "Comment": "CNM-Driven Ingest and Publish",
+  "StartAt": "CNMToGranule",
+  "States": {
+    "CNMToGranule": {
+      "Parameters": {
+        "cma": {
+          "event.$": "$",
+          "task_config": {
+            "collection": "{$.meta.collection}",
+            "cumulus_message": {
+              "outputs": [
+                {
+                  "source": "{$.cnm}",
+                  "destination": "{$.meta.granule.queryFields.cnm}"
+                },
+                {
+                  "source": "{$.cnm}",
+                  "destination": "{$.meta.cnm}"
+                },
+                {
+                  "source": "{$.output}",
+                  "destination": "{$.payload}"
+                }
+              ]
+            }
+          }
+        }
+      },
+      "Type": "Task",
+      "Resource": "${cnm_to_cma_task_arn}",
+      "Next": "Try",
+      "Retry": [
+        {
+          "ErrorEquals": [
+            "Lambda.Unknown",
+            "Lambda.ClientExecutionTimeoutException",
+            "Lambda.ServiceException",
+            "Lambda.AWSLambdaException",
+            "Lambda.SdkClientException",
+            "Lambda.TooManyRequestsException"
+          ],
+          "IntervalSeconds": 6,
+          "MaxAttempts": 6,
+          "BackoffRate": 3,
+          "JitterStrategy": "FULL"
+        },
+        {
+          "ErrorEquals": [
+            "States.ALL"
+          ],
+          "IntervalSeconds": 8,
+          "MaxAttempts": 3,
+          "BackoffRate": 2,
+          "JitterStrategy": "FULL"
+        }
+      ],
+      "Catch": [
+        {
+          "ErrorEquals": [
+            "States.ALL"
+          ],
+          "Next": "CnmResponseFail",
+          "ResultPath": "$.exception"
+        }
+      ]
+    },
+    "Try": {
+      "Type": "Parallel",
+      "Branches": [
+        {
+          "StartAt": "RequireCmrFiles",
+          "States": {
+            "RequireCmrFiles": {
+              "Type": "Task",
+              "Resource": "${require_cmr_files_task_arn}",
+              "Parameters": {
+                "cma": {
+                  "event.$": "$",
+                  "ReplaceConfig": {
+                    "MaxSize": 16384,
+                    "Path": "$.payload",
+                    "TargetPath": "$.payload"
+                  },
+                  "task_config": {
+                    "cumulus_message": {
+                      "input": "{$.payload}",
+                      "outputs": [
+                        {
+                          "source": "{$.granules}",
+                          "destination": "{$.meta.input_granules}"
+                        },
+                        {
+                          "source": "{$}",
+                          "destination": "{$.payload}"
+                        }
+                      ]
+                    }
+                  }
+                }
+              },
+              "Next": "SyncGranule",
+              "Retry": [
+                {
+                  "ErrorEquals": [
+                    "Lambda.Unknown",
+                    "Lambda.ClientExecutionTimeoutException",
+                    "Lambda.ServiceException",
+                    "Lambda.AWSLambdaException",
+                    "Lambda.SdkClientException",
+                    "Lambda.TooManyRequestsException"
+                  ],
+                  "IntervalSeconds": 4,
+                  "MaxAttempts": 6,
+                  "BackoffRate": 2,
+                  "JitterStrategy": "FULL"
+                },
+                {
+                  "ErrorEquals": [
+                    "States.ALL"
+                  ],
+                  "IntervalSeconds": 8,
+                  "MaxAttempts": 3,
+                  "BackoffRate": 2,
+                  "JitterStrategy": "FULL"
+                }
+              ]
+            },
+            "SyncGranule": {
+              "Parameters": {
+                "cma": {
+                  "event.$": "$",
+                  "ReplaceConfig": {
+                    "MaxSize": 16384,
+                    "Path": "$.payload",
+                    "TargetPath": "$.payload"
+                  },
+                  "task_config": {
+                    "buckets": "{$.meta.buckets}",
+                    "provider": "{$.meta.provider}",
+                    "collection": "{$.meta.collection}",
+                    "stack": "{$.meta.stack}",
+                    "downloadBucket": "{$.meta.buckets.protected.name}",
+                    "duplicateHandling": "{$.meta.collection.duplicateHandling}",
+                    "pdr": "{$.meta.pdr}",
+                    "cumulus_message": {
+                      "input": "{$.payload}",
+                      "outputs": [
+                        {
+                          "source": "{$.granules}",
+                          "destination": "{$.meta.input_granules}"
+                        },
+                        {
+                          "source": "{$}",
+                          "destination": "{$.payload}"
+                        },
+                        {
+                          "source": "{$.process}",
+                          "destination": "{$.meta.process}"
+                        }
+                      ]
+                    }
+                  }
+                }
+              },
+              "Type": "Task",
+              "Resource": "${sync_granule_task_arn}",
+              "Next": "AddUmmgChecksums",
+              "Retry": [
+                {
+                  "ErrorEquals": [
+                    "Lambda.Unknown",
+                    "Lambda.ClientExecutionTimeoutException",
+                    "Lambda.ServiceException",
+                    "Lambda.AWSLambdaException",
+                    "Lambda.SdkClientException",
+                    "Lambda.TooManyRequestsException"
+                  ],
+                  "IntervalSeconds": 6,
+                  "MaxAttempts": 6,
+                  "BackoffRate": 3,
+                  "JitterStrategy": "FULL"
+                },
+                {
+                  "ErrorEquals": [
+                    "States.ALL"
+                  ],
+                  "IntervalSeconds": 8,
+                  "MaxAttempts": 3,
+                  "BackoffRate": 2,
+                  "JitterStrategy": "FULL"
+                }
+              ]
+            },
+            "AddUmmgChecksums": {
+              "Type": "Task",
+              "Resource": "${add_ummg_checksums_task_arn}",
+              "Parameters": {
+                "cma": {
+                  "event.$": "$",
+                  "ReplaceConfig": {
+                    "MaxSize": 16384,
+                    "Path": "$.payload",
+                    "TargetPath": "$.payload"
+                  },
+                  "task_config": {
+                    "cumulus_message": {
+                      "input": "{$.payload}",
+                      "outputs": [
+                        {
+                          "source": "{$.granules}",
+                          "destination": "{$.meta.input_granules}"
+                        },
+                        {
+                          "source": "{$}",
+                          "destination": "{$.payload}"
+                        }
+                      ]
+                    }
+                  }
+                }
+              },
+              "Next": "AddMissingFileChecksums",
+              "Retry": [
+                {
+                  "ErrorEquals": [
+                    "Lambda.Unknown",
+                    "Lambda.ClientExecutionTimeoutException",
+                    "Lambda.ServiceException",
+                    "Lambda.AWSLambdaException",
+                    "Lambda.SdkClientException",
+                    "Lambda.TooManyRequestsException"
+                  ],
+                  "IntervalSeconds": 4,
+                  "MaxAttempts": 6,
+                  "BackoffRate": 2,
+                  "JitterStrategy": "FULL"
+                },
+                {
+                  "ErrorEquals": [
+                    "States.ALL"
+                  ],
+                  "IntervalSeconds": 8,
+                  "MaxAttempts": 3,
+                  "BackoffRate": 2,
+                  "JitterStrategy": "FULL"
+                }
+              ]
+            },
+            "AddMissingFileChecksums": {
+              "Type": "Task",
+              "Resource": "${add_missing_file_checksums_task_arn}",
+              "Parameters": {
+                "cma": {
+                  "event.$": "$",
+                  "ReplaceConfig": {
+                    "MaxSize": 16384,
+                    "Path": "$.payload",
+                    "TargetPath": "$.payload"
+                  },
+                  "task_config": {
+                    "algorithm": "md5",
+                    "cumulus_message": {
+                      "input": "{$.payload}",
+                      "outputs": [
+                        {
+                          "source": "{$.granules}",
+                          "destination": "{$.meta.input_granules}"
+                        },
+                        {
+                          "source": "{$}",
+                          "destination": "{$.payload}"
+                        }
+                      ]
+                    }
+                  }
+                }
+              },
+              "Next": "MoveGranule",
+              "Retry": [
+                {
+                  "ErrorEquals": [
+                    "Lambda.Unknown",
+                    "Lambda.ClientExecutionTimeoutException",
+                    "Lambda.ServiceException",
+                    "Lambda.AWSLambdaException",
+                    "Lambda.SdkClientException",
+                    "Lambda.TooManyRequestsException"
+                  ],
+                  "IntervalSeconds": 4,
+                  "MaxAttempts": 6,
+                  "BackoffRate": 2,
+                  "JitterStrategy": "FULL"
+                },
+                {
+                  "ErrorEquals": [
+                    "States.ALL"
+                  ],
+                  "IntervalSeconds": 8,
+                  "MaxAttempts": 3,
+                  "BackoffRate": 2,
+                  "JitterStrategy": "FULL"
+                }
+              ]
+            },
+            "MoveGranule": {
+              "Parameters": {
+                "cma": {
+                  "event.$": "$",
+                  "ReplaceConfig": {
+                    "MaxSize": 16384,
+                    "Path": "$.payload",
+                    "TargetPath": "$.payload"
+                  },
+                  "task_config": {
+                    "bucket": "{$.meta.buckets.protected.name}",
+                    "buckets": "{$.meta.buckets}",
+                    "distribution_endpoint": "{$.meta.distribution_endpoint}",
+                    "collection": "{$.meta.collection}",
+                    "duplicateHandling": "{$.meta.collection.duplicateHandling}"
+                  }
+                }
+              },
+              "Type": "Task",
+              "Resource": "${move_granules_task_arn}",
+              "Next": "UpdateMetadataFileLinks",
+              "Retry": [
+                {
+                  "ErrorEquals": [
+                    "Lambda.Unknown",
+                    "Lambda.ClientExecutionTimeoutException",
+                    "Lambda.ServiceException",
+                    "Lambda.AWSLambdaException",
+                    "Lambda.SdkClientException",
+                    "Lambda.TooManyRequestsException"
+                  ],
+                  "IntervalSeconds": 4,
+                  "MaxAttempts": 6,
+                  "BackoffRate": 2,
+                  "JitterStrategy": "FULL"
+                },
+                {
+                  "ErrorEquals": [
+                    "States.ALL"
+                  ],
+                  "IntervalSeconds": 8,
+                  "MaxAttempts": 3,
+                  "BackoffRate": 2,
+                  "JitterStrategy": "FULL"
+                }
+              ]
+            },
+            "UpdateMetadataFileLinks": {
+              "Parameters": {
+                "cma": {
+                  "event.$": "$",
+                  "ReplaceConfig": {
+                    "MaxSize": 16384,
+                    "Path": "$.payload",
+                    "TargetPath": "$.payload"
+                  },
+                  "task_config": {
+                    "buckets": "{$.meta.buckets}",
+                    "distribution_endpoint": "{$.meta.distribution_endpoint}",
+                    "cumulus_message": {
+                      "outputs": [
+                        {
+                          "source": "{$.etags}",
+                          "destination": "{$.meta.file_etags}"
+                        },
+                        {
+                          "source": "{$}",
+                          "destination": "{$.payload}"
+                        }
+                      ]
+                    }
+                  }
+                }
+              },
+              "Type": "Task",
+              "Resource": "${update_granules_cmr_metadata_file_links_task_arn}",
+              "Next": "CopyToArchive",
+              "Retry": [
+                {
+                  "ErrorEquals": [
+                    "Lambda.Unknown",
+                    "Lambda.ClientExecutionTimeoutException",
+                    "Lambda.ServiceException",
+                    "Lambda.AWSLambdaException",
+                    "Lambda.SdkClientException",
+                    "Lambda.TooManyRequestsException"
+                  ],
+                  "IntervalSeconds": 4,
+                  "MaxAttempts": 6,
+                  "BackoffRate": 2,
+                  "JitterStrategy": "FULL"
+                },
+                {
+                  "ErrorEquals": [
+                    "States.ALL"
+                  ],
+                  "IntervalSeconds": 8,
+                  "MaxAttempts": 3,
+                  "BackoffRate": 2,
+                  "JitterStrategy": "FULL"
+                }
+              ]
+            },
+            "CopyToArchive": {
+              "Parameters": {
+                "cma": {
+                  "event.$": "$",
+                  "task_config": {
+                    "s3MultipartChunksizeMb": "{$.meta.collection.meta.s3MultipartChunksizeMb}",
+                    "excludedFileExtensions": "{$.meta.collection.meta.orca.excludedFileExtensions}",
+                    "providerId": "{$.meta.provider.id}",
+                    "providerName": "{$.meta.provider.name}",
+                    "executionId": "{$.cumulus_meta.execution_name}",
+                    "collectionShortname": "{$.meta.collection.name}",
+                    "collectionVersion": "{$.meta.collection.version}",
+                    "defaultBucketOverride": "{$.meta.collection.meta.orca.defaultBucketOverride}"
+                  }
+                }
+              },
+              "Type": "Task",
+              "Resource": "${copy_to_archive_adapter_task_arn}",
+              "Next": "PostToCmr",
+              "Retry": [
+                {
+                  "ErrorEquals": [
+                    "Lambda.Unknown",
+                    "Lambda.ClientExecutionTimeoutException",
+                    "Lambda.ServiceException",
+                    "Lambda.AWSLambdaException",
+                    "Lambda.SdkClientException",
+                    "Lambda.TooManyRequestsException"
+                  ],
+                  "IntervalSeconds": 4,
+                  "MaxAttempts": 6,
+                  "BackoffRate": 2,
+                  "JitterStrategy": "FULL"
+                },
+                {
+                  "ErrorEquals": [
+                    "States.ALL"
+                  ],
+                  "IntervalSeconds": 8,
+                  "MaxAttempts": 3,
+                  "BackoffRate": 2,
+                  "JitterStrategy": "FULL"
+                }
+              ]
+            },
+            "PostToCmr": {
+              "Parameters": {
+                "cma": {
+                  "event.$": "$",
+                  "ReplaceConfig": {
+                    "MaxSize": 16384,
+                    "Path": "$.payload",
+                    "TargetPath": "$.payload"
+                  },
+                  "task_config": {
+                    "bucket": "{$.meta.buckets.internal.name}",
+                    "stack": "{$.meta.stack}",
+                    "cmr": "{$.meta.cmr}",
+                    "launchpad": "{$.meta.launchpad}",
+                    "etags": "{$.meta.file_etags}"
+                  }
+                }
+              },
+              "Type": "Task",
+              "Resource": "${post_to_cmr_task_arn}",
+              "End": true,
+              "Retry": [
+                {
+                  "ErrorEquals": [
+                    "Lambda.Unknown",
+                    "Lambda.ClientExecutionTimeoutException",
+                    "Lambda.ServiceException",
+                    "Lambda.AWSLambdaException",
+                    "Lambda.SdkClientException",
+                    "Lambda.TooManyRequestsException"
+                  ],
+                  "IntervalSeconds": 4,
+                  "MaxAttempts": 6,
+                  "BackoffRate": 2,
+                  "JitterStrategy": "FULL"
+                },
+                {
+                  "ErrorEquals": [
+                    "States.ALL"
+                  ],
+                  "IntervalSeconds": 8,
+                  "MaxAttempts": 3,
+                  "BackoffRate": 2,
+                  "JitterStrategy": "FULL"
+                }
+              ]
+            }
+          }
+        }
+      ],
+      "Catch": [
+        {
+          "ErrorEquals": [
+            "States.ALL"
+          ],
+          "Next": "CnmResponseFail",
+          "ResultPath": "$.exception"
+        }
+      ],
+      "OutputPath": "$[0]",
+      "Next": "CnmResponse"
+    },
+    "CnmResponse": {
+      "Parameters": {
+        "cma": {
+          "event.$": "$",
+          "task_config": {
+            "OriginalCNM": "{$.meta.cnm}",
+            "distribution_endpoint": "{$.meta.distribution_endpoint}",
+            "response-endpoint": "{$.meta.cnmResponseStream}",
+            "region": "us-west-2",
+            "type": "{$.meta.cnmResponseMethod}",
+            "WorkflowException": "{$.exception}",
+            "cumulus_message": {
+              "outputs": [
+                {
+                  "source": "{$.cnm}",
+                  "destination": "{$.meta.granule.queryFields.cnm}"
+                },
+                {
+                  "source": "{$.cnm}",
+                  "destination": "{$.meta.cnmResponse}"
+                },
+                {
+                  "source": "{$.input.input}",
+                  "destination": "{$.payload}"
+                }
+              ]
+            }
+          }
+        }
+      },
+      "Type": "Task",
+      "Resource": "${cnm_response_task_arn}",
+      "Next": "Succeeded",
+      "Retry": [
+        {
+          "ErrorEquals": [
+            "Lambda.Unknown",
+            "Lambda.ClientExecutionTimeoutException",
+            "Lambda.ServiceException",
+            "Lambda.AWSLambdaException",
+            "Lambda.SdkClientException",
+            "Lambda.TooManyRequestsException"
+          ],
+          "IntervalSeconds": 4,
+          "MaxAttempts": 6,
+          "BackoffRate": 2,
+          "JitterStrategy": "FULL"
+        },
+        {
+          "ErrorEquals": [
+            "States.ALL"
+          ],
+          "IntervalSeconds": 8,
+          "MaxAttempts": 3,
+          "BackoffRate": 2,
+          "JitterStrategy": "FULL"
+        }
+      ],
+      "Catch": [
+        {
+          "ErrorEquals": [
+            "States.ALL"
+          ],
+          "ResultPath": "$.exception",
+          "Next": "RecordFailure"
+        }
+      ]
+    },
+    "CnmResponseFail": {
+      "Parameters": {
+        "cma": {
+          "event.$": "$",
+          "task_config": {
+            "OriginalCNM": "{$.meta.cnm}",
+            "response-endpoint": "{$.meta.cnmResponseStream}",
+            "region": "us-west-2",
+            "type": "{$.meta.cnmResponseMethod}",
+            "WorkflowException": "{$.exception}",
+            "cumulus_message": {
+              "outputs": [
+                {
+                  "source": "{$.cnm}",
+                  "destination": "{$.meta.cnmResponse}"
+                },
+                {
+                  "source": "{$.input.input}",
+                  "destination": "{$.payload}"
+                }
+              ]
+            }
+          }
+        }
+      },
+      "Type": "Task",
+      "Resource": "${cnm_response_task_arn}",
+      "Next": "RecordFailure",
+      "Retry": [
+        {
+          "ErrorEquals": [
+            "Lambda.Unknown",
+            "Lambda.ClientExecutionTimeoutException",
+            "Lambda.ServiceException",
+            "Lambda.AWSLambdaException",
+            "Lambda.SdkClientException",
+            "Lambda.TooManyRequestsException"
+          ],
+          "IntervalSeconds": 4,
+          "MaxAttempts": 6,
+          "BackoffRate": 2,
+          "JitterStrategy": "FULL"
+        },
+        {
+          "ErrorEquals": [
+            "States.ALL"
+          ],
+          "IntervalSeconds": 8,
+          "MaxAttempts": 3,
+          "BackoffRate": 2,
+          "JitterStrategy": "FULL"
+        }
+      ],
+      "Catch": [
+        {
+          "ErrorEquals": [
+            "States.ALL"
+          ],
+          "ResultPath": "$.exception",
+          "Next": "RecordFailure"
+        }
+      ]
+    },
+    "RecordFailure": {
+      "Type": "Task",
+      "Resource": "${record_workflow_failure_task_arn}",
+      "Next": "Failed",
+      "Retry": [
+        {
+          "ErrorEquals": [
+            "Lambda.Unknown",
+            "Lambda.ClientExecutionTimeoutException",
+            "Lambda.ServiceException",
+            "Lambda.AWSLambdaException",
+            "Lambda.SdkClientException",
+            "Lambda.TooManyRequestsException"
+          ],
+          "IntervalSeconds": 4,
+          "MaxAttempts": 6,
+          "BackoffRate": 2,
+          "JitterStrategy": "FULL"
+        },
+        {
+          "ErrorEquals": [
+            "States.ALL"
+          ],
+          "IntervalSeconds": 8,
+          "MaxAttempts": 3,
+          "BackoffRate": 2,
+          "JitterStrategy": "FULL"
+        }
+      ]
+    },
+    "Succeeded": {
+      "Type": "Succeed"
+    },
+    "Failed": {
+      "Type": "Fail",
+      "Cause": "Workflow failed"
+    }
+  }
+}

--- a/bin/create-data-management-items.sh
+++ b/bin/create-data-management-items.sh
@@ -10,14 +10,37 @@ function find_provider_bucket() {
     sed -E 's/.+ = "(.+)"/\1/'
 }
 
+function fetch_cnm_params() {
+  aws ssm get-parameter --with-decryption \
+    --name "${1}" \
+    --query "Parameter.Value"
+}
+
+function find_throttle_queue_url() {
+  # Piping to sed shouldn't be necessary, but additional output may be
+  # captured if console lock requests take >400ms.
+  # See: https://github.com/hashicorp/terraform/issues/19176
+  #
+  # The final sed command should send the first line containing 'sqs' to stdout
+
+  echo "aws_sqs_queue.background_job_queue.id" |
+    terraspace console cumulus 2>/dev/null |
+    sed '/sqs/!d;q'
+}
+
 function sync_items() {
   local _path=${1}
   local _type=${2}
   local _file
 
   find "${_path}/${_type}" -name '*.json' -print0 | while IFS= read -r -d '' _file; do
-    echo -n "Upserting ${_type} $(basename "${_file}")..."
-    cumulus "${_type}" upsert --data "${_file}" >/dev/null
+    if [[ ${_file} =~ 'CNM' ]]; then
+      echo -n "Patching ${_type} $(basename "${_file}")..."
+      # cumulus "${_type}" patch --data "${_file}" >/dev/null
+    else
+      echo -n "Upserting ${_type} $(basename "${_file}")..."
+      cumulus "${_type}" upsert --data "${_file}" >/dev/null
+    fi
     echo "done"
   done
 }
@@ -49,12 +72,46 @@ function sync_providers() {
   fi
 }
 
+function sync_rules() {
+  local _resources_path=${1}
+  local _subscribe_notification_topic
+  local _publish_response_topic
+  local _queue_url
+  local _tmpdir
+
+  echo "Retrieving ARNs for CNM rules..."
+  _subscribe_notification_topic=$(fetch_cnm_params "/shared/cumulus/cnm-sns-submission-topic")
+  _publish_response_topic=$(fetch_cnm_params "/shared/cumulus/cnm-sns-response-topic")
+  _queue_url=$(find_throttle_queue_url)
+
+  if [[ ${#_subscribe_notification_topic} -le 5 || ${#_publish_response_topic} -le 5 || -z $_queue_url ]]; then
+    echo "Missing one or more ARNs for CNM rules"
+    echo "Continuing without updating current values"
+
+    sync_items "${_resources_path}" "rules"
+  else
+    _tmpdir=$(mktemp --directory)
+    # shellcheck disable=SC2064
+    trap "rm -rf \"${_tmpdir}\"" EXIT
+
+    # Copy all rules to temp directory
+    cp -r --parents "${_resources_path}/rules" "${_tmpdir}"
+
+    # Populate CNM rules with ARN properties and retrieved values
+    # shellcheck disable=SC2016
+    find "${_resources_path}/rules" -type f -name '*CNM*.json' -print0 |
+      xargs -0 -I{} sh -c 'jq ".rule.value=${1} | .meta.cnmResponseStream=${2} | .queueUrl=${3}" "${4}" >"${5}"' -- "${_subscribe_notification_topic}" "${_publish_response_topic}" "${_queue_url}" {} "${_tmpdir}/{}"
+
+    sync_items "${_tmpdir}/${_resources_path}" "rules"
+  fi
+}
+
 function main() {
   local _resources_path=app/stacks/cumulus/resources
 
   sync_providers "${_resources_path}"
   sync_items "${_resources_path}" "collections"
-  sync_items "${_resources_path}" "rules"
+  sync_rules "${_resources_path}"
 }
 
 main


### PR DESCRIPTION
## What I am changing

- Add ingestion workflow with CNM I/O
    - https://github.com/NASA-IMPACT/csda-project/issues/863
    - https://github.com/NASA-IMPACT/csda-project/issues/864
    - https://github.com/NASA-IMPACT/csda-project/issues/865
    - https://github.com/NASA-IMPACT/csda-project/issues/866
- Enable Cumulus to interact with encrypted, MCP-owned topics
    - https://github.com/NASA-IMPACT/csda-project/issues/867
- Add SNS-triggered rule management
    - https://github.com/NASA-IMPACT/csda-project/issues/865

## How I did it

- Add PO.DAAC-maintained lambdas to build
    - Download .zip files, similar to CMA layer handling
    - Create lambda resources with those .zips
- Add separate state machine to execute workflow with CNM processing pre and post-ingest
    - Align with existing convention/preference for `Parallel` states (pending further testing of CNM-specific cases)
- Add policy on processing lambda to allow use of MCP CMK
- // TODO

## How you can test it

