### PR TITLE
Github Deployment Fix (During Orca 10.1.0 UAT and PROD Deployments)

### DIFF
--- a/.github/workflows/pass.yml
+++ b/.github/workflows/pass.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   succeed-uat:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     environment: uat
     steps:
       - run: 'echo "No build required"'


### PR DESCRIPTION
Fix for github deployment issue.  Update to Github Actions for Ubuntu 22.04  #431

Context:

Github stopped allowing deployments using the runner with OS Ubuntu 20.04
This is an update to start using 22.04

Issue Reference: https://github.com/NASA-IMPACT/csdap-cumulus/actions/runs/14070177197

This PR is kind of like part 2 of this PR:
PR Reference: https://github.com/NASA-IMPACT/csdap-cumulus/pull/443

Still trying to complete the Upgrade of ORCA v10.1.0
Ticket Reference: https://github.com/NASA-IMPACT/csdap-cumulus/issues/431