### PR TITLE
Fresh Deployment corrections

### DIFF
--- a/app/stacks/cumulus/main.tf
+++ b/app/stacks/cumulus/main.tf
@@ -12,7 +12,8 @@ locals {
   cmr_provider = "CSDA"
 
   # CNM Related Update
-  cnm_to_cma_version  = "3.2.0"
+  #cnm_to_cma_version  = "3.2.0"
+  cnm_to_cma_version  = "2.1.0"
   cnm_to_cma_zip_name = "cnmToGranule-${local.cnm_to_cma_version}.zip"
   #
   cnm_response_version  = "3.2.0"
@@ -722,8 +723,9 @@ module "cumulus" {
   # <% if !in_sandbox? then %>
   log_destination_arn              = data.aws_ssm_parameter.log_destination_arn.value
   report_sns_topic_subscriber_arns = ["arn:aws:iam::${data.aws_ssm_parameter.metrics_aws_account_id.value}:root"]
-  # <% end %>
   additional_log_groups_to_elk = var.additional_log_groups_to_elk
+  # <% end %>
+  
 
   # These lines must be commented when using Cumulus Distribution and NOT using TEA
   # Thin Egress App settings. Uncomment to use TEA.

--- a/app/stacks/cumulus/variables.tf
+++ b/app/stacks/cumulus/variables.tf
@@ -9,8 +9,8 @@ variable "buckets" {
 variable "cmr_environment" {
   type = string
   validation {
-    condition     = length(regexall("^(?:UAT|OPS)$", var.cmr_environment)) == 1
-    error_message = "ERROR: Valid types are \"UAT\" and \"OPS\"!"
+    condition     = length(regexall("^(?:UAT)$", var.cmr_environment)) == 1
+    error_message = "ERROR: Valid types are \"UAT\"!"
   }
 }
 

--- a/app/stacks/rds-cluster/main.tf
+++ b/app/stacks/rds-cluster/main.tf
@@ -23,8 +23,9 @@ module "rds_cluster" {
   db_admin_password           = random_password.db_password.result
   db_admin_username           = "postgres"
   deletion_protection         = true
-  engine_version              = "13.20"
+  engine_version              = "17.4"
   parameter_group_family_v13  = "aurora-postgresql13"
+  parameter_group_family_v17  = "aurora-postgresql17"
   permissions_boundary_arn = local.permissions_boundary_arn
   prefix                   = var.prefix
   provision_user_database  = true

--- a/bin/create-data-management-items.sh
+++ b/bin/create-data-management-items.sh
@@ -53,7 +53,7 @@ function sync_providers() {
   local _provider_bucket
   local _tmpdir
 
-  if [[ ${TS_ENV} =~ ^(sit|uat|ops|prod)$ ]]; then
+  if [[ ${TS_ENV} =~ ^(sit|uat|prod)$ ]]; then
     sync_items "${_resources_path}" "providers"
   else
     echo -n "Determining provider bucket..."

--- a/config/helpers/env_helper.rb
+++ b/config/helpers/env_helper.rb
@@ -17,10 +17,11 @@ module Terraspace::Project::EnvHelper
   # account, or any deployment to the non-CBA ("old") UAT AWS account that is
   # a "development" deployment (i.e., not the official UAT deployment).
   # Conversely, any deployment that is *not* a SIT, UAT, or Prod (OPS)
-  # deployment is a sandbox deployment.
+  # deployment is a sandbox deployment.  
+  # Update: Note:, we now have a Sandbox env called OPS, had to adjust code for that.
 
   def in_sandbox?
-    %w{uat sit prod ops}.none?{ |env_part|
+    %w{uat sit prod}.none?{ |env_part|
       Terraspace.env.downcase == env_part
     }
   end


### PR DESCRIPTION
Note: During a fresh deployment of Sandbox, a few items were discovered and were corrected.  They are listed below:

- Differences from upgrade deploys to a fresh deploy.  
- Corrected cnm_to_cma version, 
- corrected Postgresql engine version definition, 
- changed definition of sandbox to remove the word ops since we now have a shared ops sandbox instance now. 
#513