### PR TITLE
Cumulus Upgrade from v21.2.0 to v21.2.1

### DIFF
--- a/app/stacks/cumulus/main.tf
+++ b/app/stacks/cumulus/main.tf
@@ -67,7 +67,7 @@ data "external" "lambda_archive_exploded" {
   program = [
     "/bin/bash",
     "-ic",
-    "yarn -s install >/dev/null && yarn -s tf:lambda:archive-exploded"
+    "yarn -s install --frozen-lockfile >/dev/null && yarn -s tf:lambda:archive-exploded"
   ]
 }
 

--- a/config/helpers/cumulus_version_helper.rb
+++ b/config/helpers/cumulus_version_helper.rb
@@ -1,5 +1,5 @@
 module Terraspace::Project::CumulusVersionHelper
   def cumulus_version
-    "v21.2.0"
+    "v21.2.1"
   end
 end

--- a/package.json
+++ b/package.json
@@ -47,9 +47,11 @@
     "version": "standard-version",
     "reset-hard": "git clean -dfx && git reset --hard && yarn",
     "prepare-release": "run-s reset-hard test cov:check doc:html version doc:publish",
+    "lambda:prune": "find ${PWD}/${npm_package_config_lambda_archive_dir} -type f \\( -name '*.d.ts' -o -name '*.d.ts.map' -o -name '*.js.map' -o -name '*.tsbuildinfo' \\) -delete && find ${PWD}/${npm_package_config_lambda_archive_dir}/node_modules -type d \\( -name test -o -name tests -o -name __tests__ -o -name doc -o -name example -o -name examples -o -name coverage -o -name benchmark -o -name benchmarks \\) -prune -exec rm -rf {} + && find ${PWD}/${npm_package_config_lambda_archive_dir}/node_modules -type f \\( -name '*.map' -o -name '*.ts' -o -name '*.md' \\) -delete",
     "lambda:install": "yarn install --production --no-bin-links --modules-folder ${PWD}/${npm_package_config_lambda_archive_dir}/node_modules && rm -rf ${PWD}/${npm_package_config_lambda_archive_dir}/node_modules/aws-sdk && rm -rf ${PWD}/${npm_package_config_lambda_archive_dir}/node_modules/'@types'",
-    "lambda:archive-exploded": "run-s build test lambda:install",
-    "tf:lambda:archive-exploded": "yarn lambda:archive-exploded >&2 && echo { '\"'dir'\"': '\"'${PWD}/${npm_package_config_lambda_archive_dir}'\"' }"
+    "lambda:archive-exploded": "run-s clean:build build test lambda:install lambda:prune lambda:diagnose-size",
+    "lambda:diagnose-size": "echo '---- lambda package sizes ----' >&2; du -sh ${PWD}/${npm_package_config_lambda_archive_dir} >&2 || true; du -sh ${PWD}/${npm_package_config_lambda_archive_dir}/node_modules >&2 || true; echo '---- largest node_modules entries ----' >&2; du -sh ${PWD}/${npm_package_config_lambda_archive_dir}/node_modules/* 2>/dev/null | sort -h | tail -40 >&2 || true",
+    "tf:lambda:archive-exploded": "yarn lambda:archive-exploded >&2 && yarn lambda:diagnose-size >&2 && echo { '\"'dir'\"': '\"'${PWD}/${npm_package_config_lambda_archive_dir}'\"' }"
   },
   "engines": {
     "node": ">=20"
@@ -60,12 +62,12 @@
     "@aws-sdk/lib-dynamodb": "^3.621.0",
     "@aws-sdk/lib-storage": "^3.621.0",
     "@aws-sdk/types": "^3.621.0",
-    "@cumulus/aws-client": "21.2.0",
-    "@cumulus/cmrjs": "21.2.0",
-    "@cumulus/common": "21.2.0",
-    "@cumulus/cumulus-message-adapter-js": "2.0.4",
+    "@cumulus/aws-client": "21.2.1",
+    "@cumulus/cmrjs": "21.2.1",
+    "@cumulus/common": "21.2.1",
+    "@cumulus/cumulus-message-adapter-js": "2.2.0",
     "@smithy/util-stream": "^2.0.17",
-    "axios": "^1.8.3",
+    "axios": "^1.13.5",
     "date-fns": "^3.0.6",
     "duration-fns": "^3.0.1",
     "follow-redirects": "^1.15.6",
@@ -82,8 +84,8 @@
   "devDependencies": {
     "@ava/typescript": "^4.1.0",
     "@aws-sdk/client-dynamodb": "^3.621.0",
-    "@cumulus/api-client": "21.2.0",
-    "@cumulus/types": "21.2.0",
+    "@cumulus/api-client": "21.2.1",
+    "@cumulus/types": "21.2.1",
     "@istanbuljs/nyc-config-typescript": "^1.0.1",
     "@tsconfig/node20": "^20.1.4",
     "@types/aws-lambda": "^8.10.85",
@@ -124,7 +126,7 @@
     "got/**/http-cache-semantics": "^4.1.1",
     "nyc/**/json5": "^2.2.2",
     "@cumulus/**/follow-redirects": "^1.15.6",
-    "@cumulus/**/axios": "^1.8.3",
+    "@cumulus/**/axios": "^1.13.5",
     "@cumulus/**/glob": "^9.0.0",
     "nyc/**/glob": "^9.0.0",
     "@cumulus/aws-client/@aws-sdk/signature-v4-crt/@aws-sdk/crt-loader/aws-crt/mqtt/help-me/glob": "^9.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -79,24 +79,24 @@
     tslib "^2.6.2"
 
 "@aws-sdk/client-api-gateway@^3.621.0":
-  version "3.1040.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/client-api-gateway/-/client-api-gateway-3.1040.0.tgz#658b4f4e43005d92637250fea77d0cc79b618e2f"
-  integrity sha512-Gfy511KeQ+DBAjs2/f9STL7vfghAAHfI5X0xiiMTP4/FYLsXjXbdKdkB9RktxK89LMpm3cBtZZqMYzYefH0JIA==
+  version "3.1044.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/client-api-gateway/-/client-api-gateway-3.1044.0.tgz#74c491a834e91f2d87ab6a33338c947e30158130"
+  integrity sha512-5HhJoGfwKhvo33QWiF4H8lu9NxOX5kvRbRCI2iq3ZUoXI1zzBXT8opZhIXWFaffzxwfQ5lew+9SZ1tF4l/SnmQ==
   dependencies:
     "@aws-crypto/sha256-browser" "5.2.0"
     "@aws-crypto/sha256-js" "5.2.0"
-    "@aws-sdk/core" "^3.974.7"
-    "@aws-sdk/credential-provider-node" "^3.972.38"
+    "@aws-sdk/core" "^3.974.8"
+    "@aws-sdk/credential-provider-node" "^3.972.39"
     "@aws-sdk/middleware-host-header" "^3.972.10"
     "@aws-sdk/middleware-logger" "^3.972.10"
     "@aws-sdk/middleware-recursion-detection" "^3.972.11"
     "@aws-sdk/middleware-sdk-api-gateway" "^3.972.10"
-    "@aws-sdk/middleware-user-agent" "^3.972.37"
+    "@aws-sdk/middleware-user-agent" "^3.972.38"
     "@aws-sdk/region-config-resolver" "^3.972.13"
     "@aws-sdk/types" "^3.973.8"
     "@aws-sdk/util-endpoints" "^3.996.8"
     "@aws-sdk/util-user-agent-browser" "^3.972.10"
-    "@aws-sdk/util-user-agent-node" "^3.973.23"
+    "@aws-sdk/util-user-agent-node" "^3.973.24"
     "@smithy/config-resolver" "^4.4.17"
     "@smithy/core" "^3.23.17"
     "@smithy/fetch-http-handler" "^5.3.17"
@@ -126,23 +126,23 @@
     tslib "^2.6.2"
 
 "@aws-sdk/client-cloudformation@^3.621.0":
-  version "3.1040.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/client-cloudformation/-/client-cloudformation-3.1040.0.tgz#346cdd496fc933368de4dac0088c49f7f9be22d3"
-  integrity sha512-dz49RtTM+RJlZBJW3f+tyl83kxkeEC9rOQPIhKJU8LPC6jONcTWp/BK53uTwUaLt673z6OfX9jgOCPcJ8zwtaQ==
+  version "3.1044.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/client-cloudformation/-/client-cloudformation-3.1044.0.tgz#c45f6ad7136931a60cf8d3d2392bdb395a7ac54c"
+  integrity sha512-2EFBp9dmQchKzfMozPYj6EO4iaauoWtYwmsK6k7Yv4jXumBRJKS7KWPbZ2pkpklFAG+OLMHPTEbIRL7ZDKPJWg==
   dependencies:
     "@aws-crypto/sha256-browser" "5.2.0"
     "@aws-crypto/sha256-js" "5.2.0"
-    "@aws-sdk/core" "^3.974.7"
-    "@aws-sdk/credential-provider-node" "^3.972.38"
+    "@aws-sdk/core" "^3.974.8"
+    "@aws-sdk/credential-provider-node" "^3.972.39"
     "@aws-sdk/middleware-host-header" "^3.972.10"
     "@aws-sdk/middleware-logger" "^3.972.10"
     "@aws-sdk/middleware-recursion-detection" "^3.972.11"
-    "@aws-sdk/middleware-user-agent" "^3.972.37"
+    "@aws-sdk/middleware-user-agent" "^3.972.38"
     "@aws-sdk/region-config-resolver" "^3.972.13"
     "@aws-sdk/types" "^3.973.8"
     "@aws-sdk/util-endpoints" "^3.996.8"
     "@aws-sdk/util-user-agent-browser" "^3.972.10"
-    "@aws-sdk/util-user-agent-node" "^3.973.23"
+    "@aws-sdk/util-user-agent-node" "^3.973.24"
     "@smithy/config-resolver" "^4.4.17"
     "@smithy/core" "^3.23.17"
     "@smithy/fetch-http-handler" "^5.3.17"
@@ -172,23 +172,23 @@
     tslib "^2.6.2"
 
 "@aws-sdk/client-cloudwatch-events@^3.621.0":
-  version "3.1040.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/client-cloudwatch-events/-/client-cloudwatch-events-3.1040.0.tgz#f8d43c8c0eafaddbb0d43ab238e12a11a2b5ad07"
-  integrity sha512-argOTmknz9Tsi2tvQTRhgRmkMWeMU+rJ7+STSzCphvTD30BZds5tn2zDVlqiifYbXBwWDH6PAKhiV9GRhY2mEA==
+  version "3.1044.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/client-cloudwatch-events/-/client-cloudwatch-events-3.1044.0.tgz#bf2f60a5d930d0d9862ba2aaf0d5267605f88318"
+  integrity sha512-0Zk1/0qUEkEj+DXGmN/f8bHL1bfIfZcQ3rpNNsbzxb/6Hpl1nIaq6EhcvbVuFIubYgvDIbo2EXh5uIVNmxQPog==
   dependencies:
     "@aws-crypto/sha256-browser" "5.2.0"
     "@aws-crypto/sha256-js" "5.2.0"
-    "@aws-sdk/core" "^3.974.7"
-    "@aws-sdk/credential-provider-node" "^3.972.38"
+    "@aws-sdk/core" "^3.974.8"
+    "@aws-sdk/credential-provider-node" "^3.972.39"
     "@aws-sdk/middleware-host-header" "^3.972.10"
     "@aws-sdk/middleware-logger" "^3.972.10"
     "@aws-sdk/middleware-recursion-detection" "^3.972.11"
-    "@aws-sdk/middleware-user-agent" "^3.972.37"
+    "@aws-sdk/middleware-user-agent" "^3.972.38"
     "@aws-sdk/region-config-resolver" "^3.972.13"
     "@aws-sdk/types" "^3.973.8"
     "@aws-sdk/util-endpoints" "^3.996.8"
     "@aws-sdk/util-user-agent-browser" "^3.972.10"
-    "@aws-sdk/util-user-agent-node" "^3.973.23"
+    "@aws-sdk/util-user-agent-node" "^3.973.24"
     "@smithy/config-resolver" "^4.4.17"
     "@smithy/core" "^3.23.17"
     "@smithy/fetch-http-handler" "^5.3.17"
@@ -217,23 +217,23 @@
     tslib "^2.6.2"
 
 "@aws-sdk/client-dynamodb-streams@^3.621.0":
-  version "3.1040.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/client-dynamodb-streams/-/client-dynamodb-streams-3.1040.0.tgz#9975d6b8cae03f4fd3ac918c58b7870a47b2120d"
-  integrity sha512-vdjfQpAoq4pyqY1ze0H3w0lKwLvogie1E9LhYbRNcERppBqVywQ4L+Mv5YFArrna8NxlPaqsJuo7ows+IztJQg==
+  version "3.1044.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/client-dynamodb-streams/-/client-dynamodb-streams-3.1044.0.tgz#b581478444b133e725d53c19800239569ea4d801"
+  integrity sha512-DGAr5Zpaidid/CSBjQjZ9MxcFuZ0XYu9EAdUSO2I31mXYd6cPga3pf3pPBeCHfQbKnwdnw81pjL0VWEANb29zw==
   dependencies:
     "@aws-crypto/sha256-browser" "5.2.0"
     "@aws-crypto/sha256-js" "5.2.0"
-    "@aws-sdk/core" "^3.974.7"
-    "@aws-sdk/credential-provider-node" "^3.972.38"
+    "@aws-sdk/core" "^3.974.8"
+    "@aws-sdk/credential-provider-node" "^3.972.39"
     "@aws-sdk/middleware-host-header" "^3.972.10"
     "@aws-sdk/middleware-logger" "^3.972.10"
     "@aws-sdk/middleware-recursion-detection" "^3.972.11"
-    "@aws-sdk/middleware-user-agent" "^3.972.37"
+    "@aws-sdk/middleware-user-agent" "^3.972.38"
     "@aws-sdk/region-config-resolver" "^3.972.13"
     "@aws-sdk/types" "^3.973.8"
     "@aws-sdk/util-endpoints" "^3.996.8"
     "@aws-sdk/util-user-agent-browser" "^3.972.10"
-    "@aws-sdk/util-user-agent-node" "^3.973.23"
+    "@aws-sdk/util-user-agent-node" "^3.973.24"
     "@smithy/config-resolver" "^4.4.17"
     "@smithy/core" "^3.23.17"
     "@smithy/fetch-http-handler" "^5.3.17"
@@ -262,25 +262,25 @@
     tslib "^2.6.2"
 
 "@aws-sdk/client-dynamodb@^3.621.0":
-  version "3.1040.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/client-dynamodb/-/client-dynamodb-3.1040.0.tgz#9b2fcc60b45278016d4b841228e14729c0a5c745"
-  integrity sha512-rxWgbYoaUwY11UnajsdJVKYYWp+ZE0AWquI2ImdPTodVcDVdYVhrxmb80my6QH1UFtOUmBCZIndx9fDT/Exp9g==
+  version "3.1044.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/client-dynamodb/-/client-dynamodb-3.1044.0.tgz#75421a223c736ba8fb06dd90a1171c03470a6c49"
+  integrity sha512-E9dZeAbyWC1YRAjdeQ7i1aK8635cQSpX4m0cUAlySiQRLux7NZa89BER07LU5OLi6ObnTi0FE7Vy0WbICUotjw==
   dependencies:
     "@aws-crypto/sha256-browser" "5.2.0"
     "@aws-crypto/sha256-js" "5.2.0"
-    "@aws-sdk/core" "^3.974.7"
-    "@aws-sdk/credential-provider-node" "^3.972.38"
-    "@aws-sdk/dynamodb-codec" "^3.973.7"
+    "@aws-sdk/core" "^3.974.8"
+    "@aws-sdk/credential-provider-node" "^3.972.39"
+    "@aws-sdk/dynamodb-codec" "^3.973.8"
     "@aws-sdk/middleware-endpoint-discovery" "^3.972.11"
     "@aws-sdk/middleware-host-header" "^3.972.10"
     "@aws-sdk/middleware-logger" "^3.972.10"
     "@aws-sdk/middleware-recursion-detection" "^3.972.11"
-    "@aws-sdk/middleware-user-agent" "^3.972.37"
+    "@aws-sdk/middleware-user-agent" "^3.972.38"
     "@aws-sdk/region-config-resolver" "^3.972.13"
     "@aws-sdk/types" "^3.973.8"
     "@aws-sdk/util-endpoints" "^3.996.8"
     "@aws-sdk/util-user-agent-browser" "^3.972.10"
-    "@aws-sdk/util-user-agent-node" "^3.973.23"
+    "@aws-sdk/util-user-agent-node" "^3.973.24"
     "@smithy/config-resolver" "^4.4.17"
     "@smithy/core" "^3.23.17"
     "@smithy/fetch-http-handler" "^5.3.17"
@@ -310,24 +310,24 @@
     tslib "^2.6.2"
 
 "@aws-sdk/client-ec2@^3.621.0":
-  version "3.1040.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/client-ec2/-/client-ec2-3.1040.0.tgz#01340bddf902bd3b71c1bf77754b59d713139c1d"
-  integrity sha512-6rUSrkRYC0xejUCCV5rsJc5XZb0RtJxDidub+653Lsl6nsWJnxakF29XVKEt8na1Qyqr0uNSMdjxvzM1Jn2Z1w==
+  version "3.1044.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/client-ec2/-/client-ec2-3.1044.0.tgz#aa0149a53036786d39531fccb78e2ecf144c9f6b"
+  integrity sha512-b4ABespJh4dskoMs316z5PupnQXdQgji46m3ZSpfUyKlQlvmlcdeuY7kO6HCGEcOgXPajzj/iquYgC2XeiRI1A==
   dependencies:
     "@aws-crypto/sha256-browser" "5.2.0"
     "@aws-crypto/sha256-js" "5.2.0"
-    "@aws-sdk/core" "^3.974.7"
-    "@aws-sdk/credential-provider-node" "^3.972.38"
+    "@aws-sdk/core" "^3.974.8"
+    "@aws-sdk/credential-provider-node" "^3.972.39"
     "@aws-sdk/middleware-host-header" "^3.972.10"
     "@aws-sdk/middleware-logger" "^3.972.10"
     "@aws-sdk/middleware-recursion-detection" "^3.972.11"
     "@aws-sdk/middleware-sdk-ec2" "^3.972.22"
-    "@aws-sdk/middleware-user-agent" "^3.972.37"
+    "@aws-sdk/middleware-user-agent" "^3.972.38"
     "@aws-sdk/region-config-resolver" "^3.972.13"
     "@aws-sdk/types" "^3.973.8"
     "@aws-sdk/util-endpoints" "^3.996.8"
     "@aws-sdk/util-user-agent-browser" "^3.972.10"
-    "@aws-sdk/util-user-agent-node" "^3.973.23"
+    "@aws-sdk/util-user-agent-node" "^3.973.24"
     "@smithy/config-resolver" "^4.4.17"
     "@smithy/core" "^3.23.17"
     "@smithy/fetch-http-handler" "^5.3.17"
@@ -357,23 +357,23 @@
     tslib "^2.6.2"
 
 "@aws-sdk/client-ecs@^3.621.0":
-  version "3.1040.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/client-ecs/-/client-ecs-3.1040.0.tgz#5282e43af43469544440f649f9434ef5a14e14ce"
-  integrity sha512-ZPBXSE7j3plPFNLhG2/J6TnW9etwVAlVSCLJLo1N+agB03ZtJP1kC2l7txxiMlcFeChXe9QX+BtRhBHeEev81g==
+  version "3.1044.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/client-ecs/-/client-ecs-3.1044.0.tgz#7618f22c6327163a1250c011eea3d1340ea41e3a"
+  integrity sha512-bdzzVBfOy1PoJCU0/1j+0nzOTHWqbnBWFQPl5K+wqVwFNgXZ7/B26NGLGVqGwamkCVLnEqnK8GBY5hZcp/9IPQ==
   dependencies:
     "@aws-crypto/sha256-browser" "5.2.0"
     "@aws-crypto/sha256-js" "5.2.0"
-    "@aws-sdk/core" "^3.974.7"
-    "@aws-sdk/credential-provider-node" "^3.972.38"
+    "@aws-sdk/core" "^3.974.8"
+    "@aws-sdk/credential-provider-node" "^3.972.39"
     "@aws-sdk/middleware-host-header" "^3.972.10"
     "@aws-sdk/middleware-logger" "^3.972.10"
     "@aws-sdk/middleware-recursion-detection" "^3.972.11"
-    "@aws-sdk/middleware-user-agent" "^3.972.37"
+    "@aws-sdk/middleware-user-agent" "^3.972.38"
     "@aws-sdk/region-config-resolver" "^3.972.13"
     "@aws-sdk/types" "^3.973.8"
     "@aws-sdk/util-endpoints" "^3.996.8"
     "@aws-sdk/util-user-agent-browser" "^3.972.10"
-    "@aws-sdk/util-user-agent-node" "^3.973.23"
+    "@aws-sdk/util-user-agent-node" "^3.973.24"
     "@smithy/config-resolver" "^4.4.17"
     "@smithy/core" "^3.23.17"
     "@smithy/fetch-http-handler" "^5.3.17"
@@ -403,23 +403,23 @@
     tslib "^2.6.2"
 
 "@aws-sdk/client-elasticsearch-service@^3.621.0":
-  version "3.1040.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/client-elasticsearch-service/-/client-elasticsearch-service-3.1040.0.tgz#8e18571d7ab6902cff4460d2ce4e55c5afb91ce1"
-  integrity sha512-YGbfr25AnFpUXwBPzQ4Mr6E5XPAoysH6kdnNRe24EScNoTnWyCidsMw2BqEu7f+5ShzoCOquVvwUUTi4yo7SzQ==
+  version "3.1044.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/client-elasticsearch-service/-/client-elasticsearch-service-3.1044.0.tgz#fc35fb058481e915aefd71efb226709d2eac2e77"
+  integrity sha512-MO/TM3SZoRAmM2PKvPBHVxxLEZfzc+Q/ztM4UPy9SOTOUkGTV9Ux0vmPMuq0QN9igLF6UVeI2mEwGqR4HhtkZQ==
   dependencies:
     "@aws-crypto/sha256-browser" "5.2.0"
     "@aws-crypto/sha256-js" "5.2.0"
-    "@aws-sdk/core" "^3.974.7"
-    "@aws-sdk/credential-provider-node" "^3.972.38"
+    "@aws-sdk/core" "^3.974.8"
+    "@aws-sdk/credential-provider-node" "^3.972.39"
     "@aws-sdk/middleware-host-header" "^3.972.10"
     "@aws-sdk/middleware-logger" "^3.972.10"
     "@aws-sdk/middleware-recursion-detection" "^3.972.11"
-    "@aws-sdk/middleware-user-agent" "^3.972.37"
+    "@aws-sdk/middleware-user-agent" "^3.972.38"
     "@aws-sdk/region-config-resolver" "^3.972.13"
     "@aws-sdk/types" "^3.973.8"
     "@aws-sdk/util-endpoints" "^3.996.8"
     "@aws-sdk/util-user-agent-browser" "^3.972.10"
-    "@aws-sdk/util-user-agent-node" "^3.973.23"
+    "@aws-sdk/util-user-agent-node" "^3.973.24"
     "@smithy/config-resolver" "^4.4.17"
     "@smithy/core" "^3.23.17"
     "@smithy/fetch-http-handler" "^5.3.17"
@@ -448,23 +448,23 @@
     tslib "^2.6.2"
 
 "@aws-sdk/client-kinesis@^3.621.0":
-  version "3.1040.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/client-kinesis/-/client-kinesis-3.1040.0.tgz#8c3e9dc925cc9c7303cb0f65d006320abadc9ecf"
-  integrity sha512-T08Cd9LRZ7RDr4wkQrOGapAG3XY0LqGOIZKB4enjO0TKk2agLTY153VrSdlKiMT4LhyCcT++6CzrWlht3dmjwQ==
+  version "3.1044.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/client-kinesis/-/client-kinesis-3.1044.0.tgz#37f35dbcf4ae268f6b0d2c77fa728febb6657208"
+  integrity sha512-z8CJZVjcbqvbXwRM4rH/oFC56SwcX7BVhW8Gq1PtCp2tXLYvA/n1QFH9rVLDVI0q84Ycm6fX+h1ey1SdxBSWhg==
   dependencies:
     "@aws-crypto/sha256-browser" "5.2.0"
     "@aws-crypto/sha256-js" "5.2.0"
-    "@aws-sdk/core" "^3.974.7"
-    "@aws-sdk/credential-provider-node" "^3.972.38"
+    "@aws-sdk/core" "^3.974.8"
+    "@aws-sdk/credential-provider-node" "^3.972.39"
     "@aws-sdk/middleware-host-header" "^3.972.10"
     "@aws-sdk/middleware-logger" "^3.972.10"
     "@aws-sdk/middleware-recursion-detection" "^3.972.11"
-    "@aws-sdk/middleware-user-agent" "^3.972.37"
+    "@aws-sdk/middleware-user-agent" "^3.972.38"
     "@aws-sdk/region-config-resolver" "^3.972.13"
     "@aws-sdk/types" "^3.973.8"
     "@aws-sdk/util-endpoints" "^3.996.8"
     "@aws-sdk/util-user-agent-browser" "^3.972.10"
-    "@aws-sdk/util-user-agent-node" "^3.973.23"
+    "@aws-sdk/util-user-agent-node" "^3.973.24"
     "@smithy/config-resolver" "^4.4.17"
     "@smithy/core" "^3.23.17"
     "@smithy/eventstream-serde-browser" "^4.2.14"
@@ -497,23 +497,23 @@
     tslib "^2.6.2"
 
 "@aws-sdk/client-kms@^3.621.0":
-  version "3.1040.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/client-kms/-/client-kms-3.1040.0.tgz#354e469d9a73d8092957b5ea8053eeedcc173701"
-  integrity sha512-mCOMxcWq2W4gx99zn05auAzxWEwsvxmQnpIe94mb1P2wXXHDj8Z8SaYM8YxC7/uUiJBOZYjhNpvJCnEEMrqB2A==
+  version "3.1044.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/client-kms/-/client-kms-3.1044.0.tgz#a67fd7d0eb7cbae1d6f3445f34d12c73a2b2c7b2"
+  integrity sha512-cDO/4ar8IcGY/GLus4FIdbqBMv2N70tHVwbApedK+cmls77afUX0RsgajGgQX19VZWId3AJrQa1jbfmSZS/q8A==
   dependencies:
     "@aws-crypto/sha256-browser" "5.2.0"
     "@aws-crypto/sha256-js" "5.2.0"
-    "@aws-sdk/core" "^3.974.7"
-    "@aws-sdk/credential-provider-node" "^3.972.38"
+    "@aws-sdk/core" "^3.974.8"
+    "@aws-sdk/credential-provider-node" "^3.972.39"
     "@aws-sdk/middleware-host-header" "^3.972.10"
     "@aws-sdk/middleware-logger" "^3.972.10"
     "@aws-sdk/middleware-recursion-detection" "^3.972.11"
-    "@aws-sdk/middleware-user-agent" "^3.972.37"
+    "@aws-sdk/middleware-user-agent" "^3.972.38"
     "@aws-sdk/region-config-resolver" "^3.972.13"
     "@aws-sdk/types" "^3.973.8"
     "@aws-sdk/util-endpoints" "^3.996.8"
     "@aws-sdk/util-user-agent-browser" "^3.972.10"
-    "@aws-sdk/util-user-agent-node" "^3.973.23"
+    "@aws-sdk/util-user-agent-node" "^3.973.24"
     "@smithy/config-resolver" "^4.4.17"
     "@smithy/core" "^3.23.17"
     "@smithy/fetch-http-handler" "^5.3.17"
@@ -542,23 +542,23 @@
     tslib "^2.6.2"
 
 "@aws-sdk/client-lambda@^3.621.0":
-  version "3.1040.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/client-lambda/-/client-lambda-3.1040.0.tgz#182c557a790f343c473e6919393169b59986725f"
-  integrity sha512-QEpUqgsKVYZXfNmZs0vREVcxDKVvT1FKYH788s3JkPa6zCmT2wBEgCqqIgKS0QdbFMMTPDYIPkIInmIFu3YWjQ==
+  version "3.1044.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/client-lambda/-/client-lambda-3.1044.0.tgz#77b5e97d622b1c760f109ca0d990a69adc716a9c"
+  integrity sha512-vWMVHylaMiXC+hbmx/ZVrxe/SL2F2veXaCs5q6KelsvT2d325D4FNFquo2q1u27WkTGN4Oe46703llBydnFL1Q==
   dependencies:
     "@aws-crypto/sha256-browser" "5.2.0"
     "@aws-crypto/sha256-js" "5.2.0"
-    "@aws-sdk/core" "^3.974.7"
-    "@aws-sdk/credential-provider-node" "^3.972.38"
+    "@aws-sdk/core" "^3.974.8"
+    "@aws-sdk/credential-provider-node" "^3.972.39"
     "@aws-sdk/middleware-host-header" "^3.972.10"
     "@aws-sdk/middleware-logger" "^3.972.10"
     "@aws-sdk/middleware-recursion-detection" "^3.972.11"
-    "@aws-sdk/middleware-user-agent" "^3.972.37"
+    "@aws-sdk/middleware-user-agent" "^3.972.38"
     "@aws-sdk/region-config-resolver" "^3.972.13"
     "@aws-sdk/types" "^3.973.8"
     "@aws-sdk/util-endpoints" "^3.996.8"
     "@aws-sdk/util-user-agent-browser" "^3.972.10"
-    "@aws-sdk/util-user-agent-node" "^3.973.23"
+    "@aws-sdk/util-user-agent-node" "^3.973.24"
     "@smithy/config-resolver" "^4.4.17"
     "@smithy/core" "^3.23.17"
     "@smithy/eventstream-serde-browser" "^4.2.14"
@@ -592,31 +592,31 @@
     tslib "^2.6.2"
 
 "@aws-sdk/client-s3@^3.621.0":
-  version "3.1040.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/client-s3/-/client-s3-3.1040.0.tgz#96fa3975b815e6cd6d0855a7bd4a72adf7dc1016"
-  integrity sha512-Ldfby1xDrlZwNY2NxP9pwdVrf8sqHbGBKP1UkoG/oWcePGlGhjY8iVwy8hRy9f1EQfHVFWIFunwHaPQxhYTnWQ==
+  version "3.1044.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/client-s3/-/client-s3-3.1044.0.tgz#acdfdc9d103320ef91dde11ae52aa2df1ae907ed"
+  integrity sha512-yT3g0Oi0b+pJBJswNxRwWLLBoExQhRx9Iz2rUy1xV0slMogTQN+DSjChI95XTDtpGEcY0qnIK6UYX0XCYdhOKg==
   dependencies:
     "@aws-crypto/sha1-browser" "5.2.0"
     "@aws-crypto/sha256-browser" "5.2.0"
     "@aws-crypto/sha256-js" "5.2.0"
-    "@aws-sdk/core" "^3.974.7"
-    "@aws-sdk/credential-provider-node" "^3.972.38"
+    "@aws-sdk/core" "^3.974.8"
+    "@aws-sdk/credential-provider-node" "^3.972.39"
     "@aws-sdk/middleware-bucket-endpoint" "^3.972.10"
     "@aws-sdk/middleware-expect-continue" "^3.972.10"
-    "@aws-sdk/middleware-flexible-checksums" "^3.974.15"
+    "@aws-sdk/middleware-flexible-checksums" "^3.974.16"
     "@aws-sdk/middleware-host-header" "^3.972.10"
     "@aws-sdk/middleware-location-constraint" "^3.972.10"
     "@aws-sdk/middleware-logger" "^3.972.10"
     "@aws-sdk/middleware-recursion-detection" "^3.972.11"
-    "@aws-sdk/middleware-sdk-s3" "^3.972.36"
+    "@aws-sdk/middleware-sdk-s3" "^3.972.37"
     "@aws-sdk/middleware-ssec" "^3.972.10"
-    "@aws-sdk/middleware-user-agent" "^3.972.37"
+    "@aws-sdk/middleware-user-agent" "^3.972.38"
     "@aws-sdk/region-config-resolver" "^3.972.13"
-    "@aws-sdk/signature-v4-multi-region" "^3.996.24"
+    "@aws-sdk/signature-v4-multi-region" "^3.996.25"
     "@aws-sdk/types" "^3.973.8"
     "@aws-sdk/util-endpoints" "^3.996.8"
     "@aws-sdk/util-user-agent-browser" "^3.972.10"
-    "@aws-sdk/util-user-agent-node" "^3.973.23"
+    "@aws-sdk/util-user-agent-node" "^3.973.24"
     "@smithy/config-resolver" "^4.4.17"
     "@smithy/core" "^3.23.17"
     "@smithy/eventstream-serde-browser" "^4.2.14"
@@ -653,23 +653,23 @@
     tslib "^2.6.2"
 
 "@aws-sdk/client-secrets-manager@^3.621.0":
-  version "3.1040.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/client-secrets-manager/-/client-secrets-manager-3.1040.0.tgz#5c1e4ea1ce194419fe4883337997802f94957c0b"
-  integrity sha512-qszI/6MUy57rSqA2eSN3jbdjU1RFUDkayw7HbSX02jRmP896mSssWM0BC+mwYXuY7d3s1QntxmMKiNwXEXRdWg==
+  version "3.1044.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/client-secrets-manager/-/client-secrets-manager-3.1044.0.tgz#6eb2ed875bf0914a9242ca403d36c1fed426be3f"
+  integrity sha512-aURP58NekytJcxe3xFDOepS6wDChlQe/sLtJbFIJjc1+ReQ1RQblmC7/pvJIUmb8swjvNCgXzgQozR+R8fw/pw==
   dependencies:
     "@aws-crypto/sha256-browser" "5.2.0"
     "@aws-crypto/sha256-js" "5.2.0"
-    "@aws-sdk/core" "^3.974.7"
-    "@aws-sdk/credential-provider-node" "^3.972.38"
+    "@aws-sdk/core" "^3.974.8"
+    "@aws-sdk/credential-provider-node" "^3.972.39"
     "@aws-sdk/middleware-host-header" "^3.972.10"
     "@aws-sdk/middleware-logger" "^3.972.10"
     "@aws-sdk/middleware-recursion-detection" "^3.972.11"
-    "@aws-sdk/middleware-user-agent" "^3.972.37"
+    "@aws-sdk/middleware-user-agent" "^3.972.38"
     "@aws-sdk/region-config-resolver" "^3.972.13"
     "@aws-sdk/types" "^3.973.8"
     "@aws-sdk/util-endpoints" "^3.996.8"
     "@aws-sdk/util-user-agent-browser" "^3.972.10"
-    "@aws-sdk/util-user-agent-node" "^3.973.23"
+    "@aws-sdk/util-user-agent-node" "^3.973.24"
     "@smithy/config-resolver" "^4.4.17"
     "@smithy/core" "^3.23.17"
     "@smithy/fetch-http-handler" "^5.3.17"
@@ -698,23 +698,23 @@
     tslib "^2.6.2"
 
 "@aws-sdk/client-sfn@^3.621.0":
-  version "3.1040.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/client-sfn/-/client-sfn-3.1040.0.tgz#cc1809965628da5eb993492310d47550fdaa4457"
-  integrity sha512-f9pig1Y2AGA95GgX3679c2xz5PGS6m3Tg62i0K1+C78SoDJ+kDASZ/muUHME/AFSIUaLdGHPdv+/qUcA3fXIZA==
+  version "3.1044.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/client-sfn/-/client-sfn-3.1044.0.tgz#4a0515addf06239fd70544b20cda335bc16cabdd"
+  integrity sha512-hOC6pJ5XKm+qVLr+gyfB/HfprUxzqqnJekVKjWO1KfbLi7Hb1LSIkVf+TjIU/aOMSFs2/QOhxTseA6vkNKkHOg==
   dependencies:
     "@aws-crypto/sha256-browser" "5.2.0"
     "@aws-crypto/sha256-js" "5.2.0"
-    "@aws-sdk/core" "^3.974.7"
-    "@aws-sdk/credential-provider-node" "^3.972.38"
+    "@aws-sdk/core" "^3.974.8"
+    "@aws-sdk/credential-provider-node" "^3.972.39"
     "@aws-sdk/middleware-host-header" "^3.972.10"
     "@aws-sdk/middleware-logger" "^3.972.10"
     "@aws-sdk/middleware-recursion-detection" "^3.972.11"
-    "@aws-sdk/middleware-user-agent" "^3.972.37"
+    "@aws-sdk/middleware-user-agent" "^3.972.38"
     "@aws-sdk/region-config-resolver" "^3.972.13"
     "@aws-sdk/types" "^3.973.8"
     "@aws-sdk/util-endpoints" "^3.996.8"
     "@aws-sdk/util-user-agent-browser" "^3.972.10"
-    "@aws-sdk/util-user-agent-node" "^3.973.23"
+    "@aws-sdk/util-user-agent-node" "^3.973.24"
     "@smithy/config-resolver" "^4.4.17"
     "@smithy/core" "^3.23.17"
     "@smithy/fetch-http-handler" "^5.3.17"
@@ -743,23 +743,23 @@
     tslib "^2.6.2"
 
 "@aws-sdk/client-sns@^3.621.0":
-  version "3.1040.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/client-sns/-/client-sns-3.1040.0.tgz#81e9321c42774722704a479ac07352cac9c17325"
-  integrity sha512-wo2cbApKoYtzBAfY3p2nvRWGQGdZGsyu18MvxrYCuG2IpYGsdNhDmApt9ErD7c0URzyfSFYZ3PlaPAs/YMrIog==
+  version "3.1044.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/client-sns/-/client-sns-3.1044.0.tgz#6cd5a048d67a42c182d2c9f28554af129af6f948"
+  integrity sha512-0vcufJrms7t4dV9yO2N71t2Nme2mavOm51eaeXEcjMRow2DY64aIqe9pO7NE+WwMeE1RqN0tUy9mH9wRaxC2/Q==
   dependencies:
     "@aws-crypto/sha256-browser" "5.2.0"
     "@aws-crypto/sha256-js" "5.2.0"
-    "@aws-sdk/core" "^3.974.7"
-    "@aws-sdk/credential-provider-node" "^3.972.38"
+    "@aws-sdk/core" "^3.974.8"
+    "@aws-sdk/credential-provider-node" "^3.972.39"
     "@aws-sdk/middleware-host-header" "^3.972.10"
     "@aws-sdk/middleware-logger" "^3.972.10"
     "@aws-sdk/middleware-recursion-detection" "^3.972.11"
-    "@aws-sdk/middleware-user-agent" "^3.972.37"
+    "@aws-sdk/middleware-user-agent" "^3.972.38"
     "@aws-sdk/region-config-resolver" "^3.972.13"
     "@aws-sdk/types" "^3.973.8"
     "@aws-sdk/util-endpoints" "^3.996.8"
     "@aws-sdk/util-user-agent-browser" "^3.972.10"
-    "@aws-sdk/util-user-agent-node" "^3.973.23"
+    "@aws-sdk/util-user-agent-node" "^3.973.24"
     "@smithy/config-resolver" "^4.4.17"
     "@smithy/core" "^3.23.17"
     "@smithy/fetch-http-handler" "^5.3.17"
@@ -788,24 +788,24 @@
     tslib "^2.6.2"
 
 "@aws-sdk/client-sqs@^3.621.0":
-  version "3.1040.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/client-sqs/-/client-sqs-3.1040.0.tgz#7f4681b8eb8949fef7e0e9c23eb4ce458b075c24"
-  integrity sha512-dzmxbJ6swad3IDAR3xTo0ju7HQKm1YMiwxWr5utZ223WagpkxnKhbAUAjPscQRzbPRLMU3ojXTDcrYEZ/IpUiw==
+  version "3.1044.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/client-sqs/-/client-sqs-3.1044.0.tgz#a7c541c93b5cf73b2d2f0d5c0fd27524eea4df63"
+  integrity sha512-Vf46G/luWJeRFTUF9gL3+IeH3CWCOxgJew9ZD5Lnd4vFMlFmlx8/SA1KFYTvmLjG9V61hVxS4u68Ssn1L9E8ow==
   dependencies:
     "@aws-crypto/sha256-browser" "5.2.0"
     "@aws-crypto/sha256-js" "5.2.0"
-    "@aws-sdk/core" "^3.974.7"
-    "@aws-sdk/credential-provider-node" "^3.972.38"
+    "@aws-sdk/core" "^3.974.8"
+    "@aws-sdk/credential-provider-node" "^3.972.39"
     "@aws-sdk/middleware-host-header" "^3.972.10"
     "@aws-sdk/middleware-logger" "^3.972.10"
     "@aws-sdk/middleware-recursion-detection" "^3.972.11"
     "@aws-sdk/middleware-sdk-sqs" "^3.972.22"
-    "@aws-sdk/middleware-user-agent" "^3.972.37"
+    "@aws-sdk/middleware-user-agent" "^3.972.38"
     "@aws-sdk/region-config-resolver" "^3.972.13"
     "@aws-sdk/types" "^3.973.8"
     "@aws-sdk/util-endpoints" "^3.996.8"
     "@aws-sdk/util-user-agent-browser" "^3.972.10"
-    "@aws-sdk/util-user-agent-node" "^3.973.23"
+    "@aws-sdk/util-user-agent-node" "^3.973.24"
     "@smithy/config-resolver" "^4.4.17"
     "@smithy/core" "^3.23.17"
     "@smithy/fetch-http-handler" "^5.3.17"
@@ -835,24 +835,24 @@
     tslib "^2.6.2"
 
 "@aws-sdk/client-sts@^3.621.0":
-  version "3.1040.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/client-sts/-/client-sts-3.1040.0.tgz#00f8881a04baff356d578a8fdc0349fe94fa2976"
-  integrity sha512-k5m8ofhqQ2102h6l0iqNFRpuSXdyhk62U9i13kmGmscfqtVX4JeKjg//IK1Mhaz6Owi6WxAl1jQ8vcx81gpzww==
+  version "3.1044.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/client-sts/-/client-sts-3.1044.0.tgz#de1801b3e8031f4a773559e4dbeafd0bbfe19168"
+  integrity sha512-ZrdRTUn2gTjQ1w7ts94e2hDiPCZ3Ze5cSZBPYF/ZI5WqxiyCdU1vetQM4NBwRfaOdusHzp7dQmoaQe0zMN821w==
   dependencies:
     "@aws-crypto/sha256-browser" "5.2.0"
     "@aws-crypto/sha256-js" "5.2.0"
-    "@aws-sdk/core" "^3.974.7"
-    "@aws-sdk/credential-provider-node" "^3.972.38"
+    "@aws-sdk/core" "^3.974.8"
+    "@aws-sdk/credential-provider-node" "^3.972.39"
     "@aws-sdk/middleware-host-header" "^3.972.10"
     "@aws-sdk/middleware-logger" "^3.972.10"
     "@aws-sdk/middleware-recursion-detection" "^3.972.11"
-    "@aws-sdk/middleware-user-agent" "^3.972.37"
+    "@aws-sdk/middleware-user-agent" "^3.972.38"
     "@aws-sdk/region-config-resolver" "^3.972.13"
-    "@aws-sdk/signature-v4-multi-region" "^3.996.24"
+    "@aws-sdk/signature-v4-multi-region" "^3.996.25"
     "@aws-sdk/types" "^3.973.8"
     "@aws-sdk/util-endpoints" "^3.996.8"
     "@aws-sdk/util-user-agent-browser" "^3.972.10"
-    "@aws-sdk/util-user-agent-node" "^3.973.23"
+    "@aws-sdk/util-user-agent-node" "^3.973.24"
     "@smithy/config-resolver" "^4.4.17"
     "@smithy/core" "^3.23.17"
     "@smithy/fetch-http-handler" "^5.3.17"
@@ -880,10 +880,10 @@
     "@smithy/util-utf8" "^4.2.2"
     tslib "^2.6.2"
 
-"@aws-sdk/core@^3.974.7":
-  version "3.974.7"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/core/-/core-3.974.7.tgz#1b78801c86f54947971ead2d4b9913a2b5b7d860"
-  integrity sha512-YhRC90ofz5oolTJZlA8voU/oUrCB2azi8Usx51k8hhB5LpWbYQMMXKUqSqkoL0Cru+RQJgWTHpAfEDDIwfUhJw==
+"@aws-sdk/core@^3.974.8":
+  version "3.974.8"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/core/-/core-3.974.8.tgz#cdd51195a31322f1e429e66919eb18da8944c081"
+  integrity sha512-njR2qoG6ZuB0kvAS2FyICsFZJ6gmCcf2X/7JcD14sUvGDm26wiZ5BrA6LOiUxKFEF+IVe7kdroxyE00YlkiYsw==
   dependencies:
     "@aws-sdk/types" "^3.973.8"
     "@aws-sdk/xml-builder" "^3.972.22"
@@ -908,23 +908,23 @@
     "@smithy/types" "^4.14.1"
     tslib "^2.6.2"
 
-"@aws-sdk/credential-provider-env@^3.972.33":
-  version "3.972.33"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.33.tgz#8a3703571871e85e064f3cabda4b7b37f2344aea"
-  integrity sha512-bJV7eViSJV6GSuuN+VIdNVPdwPsNSf75BiC2v5alPrjR/OCcqgKwSZInKbDFz9mNeizldsyf67jt6YSIiv53Cw==
+"@aws-sdk/credential-provider-env@^3.972.34":
+  version "3.972.34"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.34.tgz#9d420adf02e7604094a641ae613a353aa86e1b83"
+  integrity sha512-XT0jtf8Fw9JE6ppsQeoNnZRiG+jqRixMT1v1ZR17G60UvVdsQmTG8nbEyHuEPfMxDXEhfdARaM/XiEhca4lGHQ==
   dependencies:
-    "@aws-sdk/core" "^3.974.7"
+    "@aws-sdk/core" "^3.974.8"
     "@aws-sdk/types" "^3.973.8"
     "@smithy/property-provider" "^4.2.14"
     "@smithy/types" "^4.14.1"
     tslib "^2.6.2"
 
-"@aws-sdk/credential-provider-http@^3.972.35":
-  version "3.972.35"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.35.tgz#913eaf3a66484cb1d678ab0691943cb4f57e230d"
-  integrity sha512-x/BQGEIdq0oI+4WxLjKmnQvT7CnF9r8ezdGt7wXwxb7ckHXQz0Zmgxt8v3Ne0JaT3R5YefmuybHX6E8EnsDXyA==
+"@aws-sdk/credential-provider-http@^3.972.36":
+  version "3.972.36"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.36.tgz#842268559da2ffc5855cde1e90e7302d53639c08"
+  integrity sha512-DPoGWfy7J7RKxvbf5kOKIGQkD2ek3dbKgzKIGrnLuvZBz5myU+Im/H6pmc14QcnFbqHMqxvtWSgRDSJW3qXLQg==
   dependencies:
-    "@aws-sdk/core" "^3.974.7"
+    "@aws-sdk/core" "^3.974.8"
     "@aws-sdk/types" "^3.973.8"
     "@smithy/fetch-http-handler" "^5.3.17"
     "@smithy/node-http-handler" "^4.6.1"
@@ -935,19 +935,19 @@
     "@smithy/util-stream" "^4.5.25"
     tslib "^2.6.2"
 
-"@aws-sdk/credential-provider-ini@^3.972.37":
-  version "3.972.37"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.37.tgz#86e0d92abd993ee8866ff72865c47448a4ac1d16"
-  integrity sha512-eUTpmWfd/BKsq9medhCRcu+GRAhFP2Zrn7/2jKDHHOOjCkhrMoTp/t4cEthqFoG7gE0VGp5wUxrXTdvBCmSmJg==
+"@aws-sdk/credential-provider-ini@^3.972.38":
+  version "3.972.38"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.38.tgz#e20955fdfe4a88149b20dc7e25a517542e1dfd9f"
+  integrity sha512-oDzUBu2MGJFgoar05sPMCwSrhw44ASyccrHzj66vO69OZqi7I6hZZxXfuPLC8OCzW7C+sU+bI73XHij41yekgQ==
   dependencies:
-    "@aws-sdk/core" "^3.974.7"
-    "@aws-sdk/credential-provider-env" "^3.972.33"
-    "@aws-sdk/credential-provider-http" "^3.972.35"
-    "@aws-sdk/credential-provider-login" "^3.972.37"
-    "@aws-sdk/credential-provider-process" "^3.972.33"
-    "@aws-sdk/credential-provider-sso" "^3.972.37"
-    "@aws-sdk/credential-provider-web-identity" "^3.972.37"
-    "@aws-sdk/nested-clients" "^3.997.5"
+    "@aws-sdk/core" "^3.974.8"
+    "@aws-sdk/credential-provider-env" "^3.972.34"
+    "@aws-sdk/credential-provider-http" "^3.972.36"
+    "@aws-sdk/credential-provider-login" "^3.972.38"
+    "@aws-sdk/credential-provider-process" "^3.972.34"
+    "@aws-sdk/credential-provider-sso" "^3.972.38"
+    "@aws-sdk/credential-provider-web-identity" "^3.972.38"
+    "@aws-sdk/nested-clients" "^3.997.6"
     "@aws-sdk/types" "^3.973.8"
     "@smithy/credential-provider-imds" "^4.2.14"
     "@smithy/property-provider" "^4.2.14"
@@ -955,13 +955,13 @@
     "@smithy/types" "^4.14.1"
     tslib "^2.6.2"
 
-"@aws-sdk/credential-provider-login@^3.972.37":
-  version "3.972.37"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.37.tgz#43fd32e4140b4fe3a3c243ab21d0ac306e772e28"
-  integrity sha512-Ty68y8ISSC+g5Q3D0K8uAaoINwvfaOslnNpsF/LgVUxyosYXHawcK2yV4HLXDVugiTTYLQfJfcw0ce5meAGkKw==
+"@aws-sdk/credential-provider-login@^3.972.38":
+  version "3.972.38"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.38.tgz#278437712c02a3ad1785f70c93b4f591cb3f6491"
+  integrity sha512-g1NosS8qe4OF++G2UFCM5ovSkgipC7YYor5KCWatG0UoMSO5YFj9C8muePlyVmOBV/WTI16Jo3/s1NUo/o1Bww==
   dependencies:
-    "@aws-sdk/core" "^3.974.7"
-    "@aws-sdk/nested-clients" "^3.997.5"
+    "@aws-sdk/core" "^3.974.8"
+    "@aws-sdk/nested-clients" "^3.997.6"
     "@aws-sdk/types" "^3.973.8"
     "@smithy/property-provider" "^4.2.14"
     "@smithy/protocol-http" "^5.3.14"
@@ -969,17 +969,17 @@
     "@smithy/types" "^4.14.1"
     tslib "^2.6.2"
 
-"@aws-sdk/credential-provider-node@^3.972.38":
-  version "3.972.38"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.38.tgz#2fc1742b626c6b80534e42ae91359a25262e9e91"
-  integrity sha512-BQ9XYnBDVxR2HuV5huXYQYF/PZMTsY+EnwfGnCU2cA8Zw63XpkOtPY8WqiMIZMQCrKPQQEiFURS/o9CIolRLqg==
+"@aws-sdk/credential-provider-node@^3.972.39":
+  version "3.972.39"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.39.tgz#71f87848b7615dda4f31a57b113be9666e4bbd1a"
+  integrity sha512-HEswDQyxUtadoZ/bJsPPENHg7R0Lzym5LuMksJeHvqhCOpP+rtkDLKI4/ZChH4w3cf5kG8n6bZuI8PzajoiqMg==
   dependencies:
-    "@aws-sdk/credential-provider-env" "^3.972.33"
-    "@aws-sdk/credential-provider-http" "^3.972.35"
-    "@aws-sdk/credential-provider-ini" "^3.972.37"
-    "@aws-sdk/credential-provider-process" "^3.972.33"
-    "@aws-sdk/credential-provider-sso" "^3.972.37"
-    "@aws-sdk/credential-provider-web-identity" "^3.972.37"
+    "@aws-sdk/credential-provider-env" "^3.972.34"
+    "@aws-sdk/credential-provider-http" "^3.972.36"
+    "@aws-sdk/credential-provider-ini" "^3.972.38"
+    "@aws-sdk/credential-provider-process" "^3.972.34"
+    "@aws-sdk/credential-provider-sso" "^3.972.38"
+    "@aws-sdk/credential-provider-web-identity" "^3.972.38"
     "@aws-sdk/types" "^3.973.8"
     "@smithy/credential-provider-imds" "^4.2.14"
     "@smithy/property-provider" "^4.2.14"
@@ -987,60 +987,60 @@
     "@smithy/types" "^4.14.1"
     tslib "^2.6.2"
 
-"@aws-sdk/credential-provider-process@^3.972.33":
-  version "3.972.33"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.33.tgz#9f5ae9a63e76fcdaf684c03e5479c2e53305ce1c"
-  integrity sha512-yfjGksI9WQbdMObb0VeLXqzTLI+a0qXLJT9gCDiv0+X/xjPpI3mTz6a5FibrhpuEKIe0gSgvs3MaoFZy5cx4WA==
+"@aws-sdk/credential-provider-process@^3.972.34":
+  version "3.972.34"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.34.tgz#c964275be1a528ac73ade6d98c309fb6b7cdfb68"
+  integrity sha512-T3IFs4EVmVi1dVN5RciFnklCANSzvrQd/VuHY9ThHSQmYkTogjcGkoJEr+oNUPQZnso52183088NqysMPji1/Q==
   dependencies:
-    "@aws-sdk/core" "^3.974.7"
+    "@aws-sdk/core" "^3.974.8"
     "@aws-sdk/types" "^3.973.8"
     "@smithy/property-provider" "^4.2.14"
     "@smithy/shared-ini-file-loader" "^4.4.9"
     "@smithy/types" "^4.14.1"
     tslib "^2.6.2"
 
-"@aws-sdk/credential-provider-sso@^3.972.37":
-  version "3.972.37"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.37.tgz#91cdba4a3aef35c1b4178610db782dfc8a6bc490"
-  integrity sha512-fpwE+20ntpp3i9Xb9vUuQfXLDKYHH+5I2V+ZG96SX1nBzrruhy10RXDgmN7t1etOz3c55stlA3TeQASUA451NQ==
+"@aws-sdk/credential-provider-sso@^3.972.38":
+  version "3.972.38"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.38.tgz#ec754bfecb2426a3307e19ef7e6c6b6438a327c6"
+  integrity sha512-5ZxG+t0+3Q3QPh8KEjX6syskhgNf7I0MN7oGioTf6Lm1NTjfP7sIcYGNsthXC2qR8vcD3edNZwCr2ovfSSWuRA==
   dependencies:
-    "@aws-sdk/core" "^3.974.7"
-    "@aws-sdk/nested-clients" "^3.997.5"
-    "@aws-sdk/token-providers" "3.1039.0"
+    "@aws-sdk/core" "^3.974.8"
+    "@aws-sdk/nested-clients" "^3.997.6"
+    "@aws-sdk/token-providers" "3.1041.0"
     "@aws-sdk/types" "^3.973.8"
     "@smithy/property-provider" "^4.2.14"
     "@smithy/shared-ini-file-loader" "^4.4.9"
     "@smithy/types" "^4.14.1"
     tslib "^2.6.2"
 
-"@aws-sdk/credential-provider-web-identity@^3.972.37":
-  version "3.972.37"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.37.tgz#9b74f250a644f9d6248950e02ed311b0b4959d3e"
-  integrity sha512-aryawqyebf+3WhAFNHfF62rekFpYtVcVN7dQ89qnAWsa4n5hJst8qBG6gXC24WHtW7Nnhkf9ScYnjwo0Brn3bw==
+"@aws-sdk/credential-provider-web-identity@^3.972.38":
+  version "3.972.38"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.38.tgz#149951ef6e12db5292118e8ed5d95133c24ad719"
+  integrity sha512-lYHFF30DGI20jZcYX8cm6Ns0V7f1dDN6g/MBDLTyD/5iw+bXs3yBr2iAiHDkx4RFU5JgsnZvCHYKiRVPRdmOgw==
   dependencies:
-    "@aws-sdk/core" "^3.974.7"
-    "@aws-sdk/nested-clients" "^3.997.5"
+    "@aws-sdk/core" "^3.974.8"
+    "@aws-sdk/nested-clients" "^3.997.6"
     "@aws-sdk/types" "^3.973.8"
     "@smithy/property-provider" "^4.2.14"
     "@smithy/shared-ini-file-loader" "^4.4.9"
     "@smithy/types" "^4.14.1"
     tslib "^2.6.2"
 
-"@aws-sdk/crt-loader@^3.972.37":
-  version "3.972.37"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/crt-loader/-/crt-loader-3.972.37.tgz#43b6d8090df7469c547cbc1ab98cdd1b7fba79dc"
-  integrity sha512-n2gpUJzy9hMXZXw65t5mdmT18ZE7BtRSdJDG/YZYhsgKIo/dQ6PzcRxvZdPcSS5zkESy+1Ltn0WUrt93nwaxtA==
+"@aws-sdk/crt-loader@^3.972.38":
+  version "3.972.38"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/crt-loader/-/crt-loader-3.972.38.tgz#d3a9216df793644e658963c19e629e1b3929994d"
+  integrity sha512-l/qPBy5btFaXpv9Pl1MejtkcchvIhG0jW8ZHBnnMiMvVHLuv3jupR0ANJ1jUOi1lAZB9U6kW0MJ4RF6oGVA8Rw==
   dependencies:
-    "@aws-sdk/util-user-agent-node" "^3.973.23"
+    "@aws-sdk/util-user-agent-node" "^3.973.24"
     aws-crt "^1.24.0"
     tslib "^2.6.2"
 
-"@aws-sdk/dynamodb-codec@^3.973.7":
-  version "3.973.7"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/dynamodb-codec/-/dynamodb-codec-3.973.7.tgz#c19a1550bde6783ae726cb5fc323c14776a08ff1"
-  integrity sha512-9NIOxillGcBp/355NoQo7kPalYIe8fJkgS00ZgO6qKLsiDmCgCoHGiT7yIuavWhsSbYcYIa8Z+BLdfnPtr5kSA==
+"@aws-sdk/dynamodb-codec@^3.973.8":
+  version "3.973.8"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/dynamodb-codec/-/dynamodb-codec-3.973.8.tgz#e2f0a451eef83a0163e73625fdf7fd1e5b8c110d"
+  integrity sha512-dYQ/cQqHZd23hcl8oEGwPphTqyGnmvf2HrVmz4J90Q5Bv89oJjlwcBcifiiTvApqsVpx7Pr0IebMpkYwWJvZlQ==
   dependencies:
-    "@aws-sdk/core" "^3.974.7"
+    "@aws-sdk/core" "^3.974.8"
     "@smithy/core" "^3.23.17"
     "@smithy/types" "^4.14.1"
     "@smithy/util-base64" "^4.3.2"
@@ -1055,11 +1055,11 @@
     tslib "^2.6.2"
 
 "@aws-sdk/lib-dynamodb@^3.621.0":
-  version "3.1040.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/lib-dynamodb/-/lib-dynamodb-3.1040.0.tgz#2fe512e4e683cb5b85ac795d3b43ebe520db74eb"
-  integrity sha512-LlOQI14tXceVsiKbzMxGkmjSgAv/vmRwIz/HV/rWmRmbjIT2b8jA51jnj+hTvJbPomoOIKb0T+tz6LwJrK+HDw==
+  version "3.1044.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/lib-dynamodb/-/lib-dynamodb-3.1044.0.tgz#387ac3dd1fdfb96d2a54203dcc6e9ad9b8235625"
+  integrity sha512-dM99udP+INg/BJwekh5246Ah2oZeEKFruNVxQZEyiymcXAxm0W1CWAXLnJ7PyXBVezE7zByRm5wsNqjoUcP+kw==
   dependencies:
-    "@aws-sdk/core" "^3.974.7"
+    "@aws-sdk/core" "^3.974.8"
     "@aws-sdk/util-dynamodb" "^3.996.2"
     "@smithy/core" "^3.23.17"
     "@smithy/smithy-client" "^4.12.13"
@@ -1067,9 +1067,9 @@
     tslib "^2.6.2"
 
 "@aws-sdk/lib-storage@^3.621.0":
-  version "3.1040.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/lib-storage/-/lib-storage-3.1040.0.tgz#c9b3839ba75fdf35c9302f2a003087b042128587"
-  integrity sha512-4cPpxs/2Gnzm7dKn2EBTPf0/rPNM5BoOleWSNn03QPGkELPDg9VmVwUhXZsDcb8k8F9wm5ft9n7BSNXKAjoIWw==
+  version "3.1044.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/lib-storage/-/lib-storage-3.1044.0.tgz#113736cc39a7f0422bab52a3621a87041ad573d5"
+  integrity sha512-VMyTkaF87RwDmrNPMmfxRADc4SIU0P85q/WzMpr+6e8MfLzHA/lUSkndM4FLEcEBh/AYUUqbBPHxs+WT6xIHLA==
   dependencies:
     "@smithy/middleware-endpoint" "^4.4.32"
     "@smithy/protocol-http" "^5.3.14"
@@ -1115,15 +1115,15 @@
     "@smithy/types" "^4.14.1"
     tslib "^2.6.2"
 
-"@aws-sdk/middleware-flexible-checksums@^3.974.15":
-  version "3.974.15"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.974.15.tgz#11e688424dd08fae175d08597dd2a7edeaa4773a"
-  integrity sha512-j4Zp7rA1HfhDTteICnx/tPax4N/v5wmytgguXExUGyEwQ8Ug4EBA4kjp9puFAN1UZoBVpxoiXMiuTFvjaHjeEw==
+"@aws-sdk/middleware-flexible-checksums@^3.974.16":
+  version "3.974.16"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.974.16.tgz#89b78cb0ad389aba7d12d060f46017e1fa3784a9"
+  integrity sha512-6ru8doI0/XzszqLIPXf0E/V7HhAw1Pu94010XCKYtBUfD0LxF0BuOzrUf8OQGR6j2o6wgKTHUniOmndQycHwCA==
   dependencies:
     "@aws-crypto/crc32" "5.2.0"
     "@aws-crypto/crc32c" "5.2.0"
     "@aws-crypto/util" "5.2.0"
-    "@aws-sdk/core" "^3.974.7"
+    "@aws-sdk/core" "^3.974.8"
     "@aws-sdk/crc64-nvme" "^3.972.7"
     "@aws-sdk/types" "^3.973.8"
     "@smithy/is-array-buffer" "^4.2.2"
@@ -1198,12 +1198,12 @@
     "@smithy/types" "^4.14.1"
     tslib "^2.6.2"
 
-"@aws-sdk/middleware-sdk-s3@^3.972.36":
-  version "3.972.36"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.36.tgz#d67c778ca2c385a35ef48986d547dd4693fb6a0a"
-  integrity sha512-YhPix+0x/MdQrb1Ug1GDKeS5fqylIy+naz800asX8II4jqfTk2KY2KhmmYCwZcky8YWtRQQwWCGdoqeAnip8Uw==
+"@aws-sdk/middleware-sdk-s3@^3.972.37":
+  version "3.972.37"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.37.tgz#82ef4953cddd3373d2942d07a5d2baf443bbf3ea"
+  integrity sha512-Km7M+i8DrLArVzrid1gfxeGhYHBd3uxvE77g0s5a52zPSVosxzQBnJ0gwWb6NIp/DOk8gsBMhi7V+cpJG0ndTA==
   dependencies:
-    "@aws-sdk/core" "^3.974.7"
+    "@aws-sdk/core" "^3.974.8"
     "@aws-sdk/types" "^3.973.8"
     "@aws-sdk/util-arn-parser" "^3.972.3"
     "@smithy/core" "^3.23.17"
@@ -1239,12 +1239,12 @@
     "@smithy/types" "^4.14.1"
     tslib "^2.6.2"
 
-"@aws-sdk/middleware-user-agent@^3.972.37":
-  version "3.972.37"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.37.tgz#61ee85d964a3f36091a5b36dea630fb30e8e6913"
-  integrity sha512-N1oNpdiLoVAWYD3WFBnUi3LlfoDA06ZHo4ozyjbsJNLvILzvt//0CnR8N+CZ0NWeYgVB/5V59ivixHCWCx2ALw==
+"@aws-sdk/middleware-user-agent@^3.972.38":
+  version "3.972.38"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.38.tgz#626d9a2499f5a6398a4db917abeeaac14b54c6cb"
+  integrity sha512-iz+B29TXcAZsJpwB+AwG/TTGA5l/VnmMZ2UxtiySOZjI6gCdmviXPwdgzcmuazMy16rXoPY4mYCGe7zdNKfx5A==
   dependencies:
-    "@aws-sdk/core" "^3.974.7"
+    "@aws-sdk/core" "^3.974.8"
     "@aws-sdk/types" "^3.973.8"
     "@aws-sdk/util-endpoints" "^3.996.8"
     "@smithy/core" "^3.23.17"
@@ -1253,24 +1253,24 @@
     "@smithy/util-retry" "^4.3.6"
     tslib "^2.6.2"
 
-"@aws-sdk/nested-clients@^3.997.5":
-  version "3.997.5"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/nested-clients/-/nested-clients-3.997.5.tgz#0b66825b14b1a06b43b71e95354f22cb6b4926df"
-  integrity sha512-jGFr6DxtcMTmzOkG/a0jCZYv4BBDmeNYVeO+/memSoDkYCJu4Y58xviYmzwJfYyIVSts+X/BVjJm1uGBnwHEMg==
+"@aws-sdk/nested-clients@^3.997.6":
+  version "3.997.6"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/nested-clients/-/nested-clients-3.997.6.tgz#17433cfac2160ec620a14cbff9d2b33675712cae"
+  integrity sha512-WBDnqatJl+kGObpfmfSxqnXeYTu3Me8wx8WCtvoxX3pfWrrTv8I4WTMSSs7PZqcRcVh8WeUKMgGFjMG+52SR1w==
   dependencies:
     "@aws-crypto/sha256-browser" "5.2.0"
     "@aws-crypto/sha256-js" "5.2.0"
-    "@aws-sdk/core" "^3.974.7"
+    "@aws-sdk/core" "^3.974.8"
     "@aws-sdk/middleware-host-header" "^3.972.10"
     "@aws-sdk/middleware-logger" "^3.972.10"
     "@aws-sdk/middleware-recursion-detection" "^3.972.11"
-    "@aws-sdk/middleware-user-agent" "^3.972.37"
+    "@aws-sdk/middleware-user-agent" "^3.972.38"
     "@aws-sdk/region-config-resolver" "^3.972.13"
-    "@aws-sdk/signature-v4-multi-region" "^3.996.24"
+    "@aws-sdk/signature-v4-multi-region" "^3.996.25"
     "@aws-sdk/types" "^3.973.8"
     "@aws-sdk/util-endpoints" "^3.996.8"
     "@aws-sdk/util-user-agent-browser" "^3.972.10"
-    "@aws-sdk/util-user-agent-node" "^3.973.23"
+    "@aws-sdk/util-user-agent-node" "^3.973.24"
     "@smithy/config-resolver" "^4.4.17"
     "@smithy/core" "^3.23.17"
     "@smithy/fetch-http-handler" "^5.3.17"
@@ -1310,11 +1310,11 @@
     tslib "^2.6.2"
 
 "@aws-sdk/s3-request-presigner@^3.621.0":
-  version "3.1040.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/s3-request-presigner/-/s3-request-presigner-3.1040.0.tgz#c81d96024325436dd4ff0f412ca5c22d2674a6e6"
-  integrity sha512-AmesZGG/B5sDIiWahyY11fOkXSsuHc7LciE88YFURehMVSdEORo2Vzz1d2kBgmJG9oar5Vmmwf9X/w7mqb7ytg==
+  version "3.1044.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/s3-request-presigner/-/s3-request-presigner-3.1044.0.tgz#5ec1dc373498746b86ca51156763577b7d65510e"
+  integrity sha512-ix8UtiNC5g1wv3TIcgTnvWdugyw8dSsBGwZZzVVoGyYjZH9UJLqiOyvVu6apptlPBeE6aV6Fabsx0b1xYFd2ZA==
   dependencies:
-    "@aws-sdk/signature-v4-multi-region" "^3.996.24"
+    "@aws-sdk/signature-v4-multi-region" "^3.996.25"
     "@aws-sdk/types" "^3.973.8"
     "@aws-sdk/util-format-url" "^3.972.10"
     "@smithy/middleware-endpoint" "^4.4.32"
@@ -1324,12 +1324,12 @@
     tslib "^2.6.2"
 
 "@aws-sdk/signature-v4-crt@^3.621.0":
-  version "3.1040.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/signature-v4-crt/-/signature-v4-crt-3.1040.0.tgz#891ceea644a6958d0b7cd06a21506c390c26b17d"
-  integrity sha512-AdZGUdwhz0RWhSK7OuEOwKoYovFd7WlnXfZ+uR/X3PgPKAba2N0QH7GezLmArKSgr+uzRJ8CVt4Ga+w/T/lvFw==
+  version "3.1044.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/signature-v4-crt/-/signature-v4-crt-3.1044.0.tgz#75f14aef0d366b372a71c1b090f63832a3a25d69"
+  integrity sha512-Vn41yQrVrQItO3l+Vm4g7pofjO/3nzHTY33fHB3dFPXrLOhUg3LbVrrhzUOVlYsyjO/8tU3TGVsaKz3ehNWJHA==
   dependencies:
-    "@aws-sdk/crt-loader" "^3.972.37"
-    "@aws-sdk/signature-v4-multi-region" "^3.996.24"
+    "@aws-sdk/crt-loader" "^3.972.38"
+    "@aws-sdk/signature-v4-multi-region" "^3.996.25"
     "@aws-sdk/types" "^3.973.8"
     "@smithy/querystring-parser" "^4.2.14"
     "@smithy/signature-v4" "^5.3.14"
@@ -1337,25 +1337,25 @@
     "@smithy/util-middleware" "^4.2.14"
     tslib "^2.6.2"
 
-"@aws-sdk/signature-v4-multi-region@^3.996.24":
-  version "3.996.24"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.24.tgz#efe204595832e418aad404163f55d7ffc7d21dad"
-  integrity sha512-amP7tLikppN940wbBFISYqiuzVmpzMS9U3mcgtmVLjX4fdWI/SNCvrXv6ZxfVzTT4cT0rPKOLhFah2xLwzREWw==
+"@aws-sdk/signature-v4-multi-region@^3.996.25":
+  version "3.996.25"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.25.tgz#b50651b7e4f9c82482416caa9953ad17645d4a2d"
+  integrity sha512-+CMIt3e1VzlklAECmG+DtP1sV8iKq25FuA0OKpnJ4KA0kxUtd7CgClY7/RU6VzJBQwbN4EJ9Ue6plvqx1qGadw==
   dependencies:
-    "@aws-sdk/middleware-sdk-s3" "^3.972.36"
+    "@aws-sdk/middleware-sdk-s3" "^3.972.37"
     "@aws-sdk/types" "^3.973.8"
     "@smithy/protocol-http" "^5.3.14"
     "@smithy/signature-v4" "^5.3.14"
     "@smithy/types" "^4.14.1"
     tslib "^2.6.2"
 
-"@aws-sdk/token-providers@3.1039.0":
-  version "3.1039.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/token-providers/-/token-providers-3.1039.0.tgz#98fac2aa3c22d2ba8b2375d35dcd67f96ea3e990"
-  integrity sha512-NMSFL2HwkAOoCeLCQiqoOq5pT3vVbSjww2QZTuYgYknVwhhv125PSDzZIcL5EYnlxuPWjEOdauZK+FspkZDVdw==
+"@aws-sdk/token-providers@3.1041.0":
+  version "3.1041.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/token-providers/-/token-providers-3.1041.0.tgz#f3f068010780fc85fc4a7faa6a080cfb8afd73a4"
+  integrity sha512-Th7kPI6YPtvJUcdznooXJMy+9rQWjmEF81LxaJssngBzuysK4a/x+l8kjm1zb7nYsUPbndnBdUnwng/3PLvtGw==
   dependencies:
-    "@aws-sdk/core" "^3.974.7"
-    "@aws-sdk/nested-clients" "^3.997.5"
+    "@aws-sdk/core" "^3.974.8"
+    "@aws-sdk/nested-clients" "^3.997.6"
     "@aws-sdk/types" "^3.973.8"
     "@smithy/property-provider" "^4.2.14"
     "@smithy/shared-ini-file-loader" "^4.4.9"
@@ -1422,12 +1422,12 @@
     bowser "^2.11.0"
     tslib "^2.6.2"
 
-"@aws-sdk/util-user-agent-node@^3.973.23":
-  version "3.973.23"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.973.23.tgz#3e29535e887ad72deaecdfd4667ec710e4086f90"
-  integrity sha512-gGwq8L2Euw0aNG6Ey4EktiAo3fSCVoDy1CaBIthd+oeaKHPXUrNaApMewQ6La5Hv0lcznOtECZaNvYyc5LXXfA==
+"@aws-sdk/util-user-agent-node@^3.973.24":
+  version "3.973.24"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.973.24.tgz#cf44a63b92adfecaeb8cb9f948b390456310566a"
+  integrity sha512-ZWwlkjcIp7cEL8ZfTpTAPNkwx25p7xol0xlKoWVVf22+nsjwmLcHYtTPjIV1cSpmB/b6DaK4cb1fSkvCXHgRdw==
   dependencies:
-    "@aws-sdk/middleware-user-agent" "^3.972.37"
+    "@aws-sdk/middleware-user-agent" "^3.972.38"
     "@aws-sdk/types" "^3.973.8"
     "@smithy/node-config-provider" "^4.3.14"
     "@smithy/types" "^4.14.1"
@@ -1466,9 +1466,9 @@
     picocolors "^1.1.1"
 
 "@babel/compat-data@^7.28.6":
-  version "7.29.0"
-  resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.29.0.tgz#00d03e8c0ac24dd9be942c5370990cbe1f17d88d"
-  integrity sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==
+  version "7.29.3"
+  resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.29.3.tgz#e3f5347f0589596c91d227ccb6a541d37fb1307b"
+  integrity sha512-LIVqM46zQWZhj17qA8wb4nW/ixr2y1Nw+r1etiAWgRM6U1IqP+LNhL1yg440jYZR72jCWcWbLWzIosH+uP1fqg==
 
 "@babel/core@^7.7.5":
   version "7.29.0"
@@ -1559,9 +1559,9 @@
     "@babel/types" "^7.29.0"
 
 "@babel/parser@^7.28.6", "@babel/parser@^7.29.0":
-  version "7.29.2"
-  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.29.2.tgz#58bd50b9a7951d134988a1ae177a35ef9a703ba1"
-  integrity sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==
+  version "7.29.3"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.29.3.tgz#116f70a77958307fceac27747573032f8a62f88e"
+  integrity sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==
   dependencies:
     "@babel/types" "^7.29.0"
 
@@ -1650,20 +1650,20 @@
   dependencies:
     "@jridgewell/trace-mapping" "0.3.9"
 
-"@cumulus/api-client@21.2.0":
-  version "21.2.0"
-  resolved "https://registry.yarnpkg.com/@cumulus/api-client/-/api-client-21.2.0.tgz#241cb9d6e32206f248c1785f3386c6472cb76796"
-  integrity sha512-Vycxr7qRI+ILCUvxp7fB3VIwYMyEaiiuD41aSEifpCokPTvJNFebXWix6d35JJfaH7o7nfWVuDvU1y69GEOZ0Q==
+"@cumulus/api-client@21.2.1":
+  version "21.2.1"
+  resolved "https://registry.yarnpkg.com/@cumulus/api-client/-/api-client-21.2.1.tgz#9a1fdb23b36e67f435cde7f71d4e948b1b94c9bc"
+  integrity sha512-05q9Lt3jLtYdpVybQ90f2pxsQ0A9UWkhzeNtD8xQYE6+ftMkHcxo2blDeDqwEOgtaAAYNO84xGIWSrY2R5EShw==
   dependencies:
     "@aws-sdk/client-lambda" "^3.621.0"
-    "@cumulus/aws-client" "21.2.0"
-    "@cumulus/logger" "21.2.0"
+    "@cumulus/aws-client" "21.2.1"
+    "@cumulus/logger" "21.2.1"
     p-retry "^2.0.0"
 
-"@cumulus/aws-client@21.2.0":
-  version "21.2.0"
-  resolved "https://registry.yarnpkg.com/@cumulus/aws-client/-/aws-client-21.2.0.tgz#32f637b870d54ac770e536a9b1b4d0e0e814d5bd"
-  integrity sha512-NASbNiuVrJ0vqYSKY+o1N5cCNdNQ1jpEVFdcRJ1IJ6V1+e7CG7rDc/sBMEY9oX4+yibllEcAW1kRi3ijHzUkRw==
+"@cumulus/aws-client@21.2.1":
+  version "21.2.1"
+  resolved "https://registry.yarnpkg.com/@cumulus/aws-client/-/aws-client-21.2.1.tgz#ac44d6fa8f7d49d588c1a3441ba49f84dfadc1f6"
+  integrity sha512-YzyprlTit2oDXWGXQdY6CNiaEa+9INHfvCjH892MvzT76NzvwQ/P4pvxYWT1HCG7EHOvNF3Ap/L6N/hni8qsJQ==
   dependencies:
     "@aws-sdk/client-api-gateway" "^3.621.0"
     "@aws-sdk/client-cloudformation" "^3.621.0"
@@ -1687,10 +1687,10 @@
     "@aws-sdk/s3-request-presigner" "^3.621.0"
     "@aws-sdk/signature-v4-crt" "^3.621.0"
     "@aws-sdk/types" "^3.609.0"
-    "@cumulus/checksum" "21.2.0"
-    "@cumulus/errors" "21.2.0"
-    "@cumulus/logger" "21.2.0"
-    "@cumulus/types" "21.2.0"
+    "@cumulus/checksum" "21.2.1"
+    "@cumulus/errors" "21.2.1"
+    "@cumulus/logger" "21.2.1"
+    "@cumulus/types" "21.2.1"
     lodash "~4.17.21"
     mem "^8.0.2"
     p-map "^1.2.0"
@@ -1700,22 +1700,22 @@
     pump "^3.0.0"
     uuid "^8.2.0"
 
-"@cumulus/checksum@21.2.0":
-  version "21.2.0"
-  resolved "https://registry.yarnpkg.com/@cumulus/checksum/-/checksum-21.2.0.tgz#a54bedf7b087810b181c47e7b36f5b3feae615f8"
-  integrity sha512-ZPdUUEjfpvVVzzIJtKzBYS1AtM5oLTi6Wi/Qh+jd/Qz40lTvXwY1D2Lc9yQRnVd1ni5hgVZ5jaVSCMw+CtHGyQ==
+"@cumulus/checksum@21.2.1":
+  version "21.2.1"
+  resolved "https://registry.yarnpkg.com/@cumulus/checksum/-/checksum-21.2.1.tgz#aefd905fef8d5c09159fc36ca6405e39cd2897f7"
+  integrity sha512-rInVg6d1LhJ9c8rkuNwcJ7tZE65veRJr7ve6Lq1yDdHVEyExhG86m43bX1Xp4IVTCWavN5KwfCgl3dOUl1XOLg==
   dependencies:
     cksum "^1.3.0"
 
-"@cumulus/cmr-client@21.2.0":
-  version "21.2.0"
-  resolved "https://registry.yarnpkg.com/@cumulus/cmr-client/-/cmr-client-21.2.0.tgz#d96432a2cbc39aa732b37407576c6fe77643df69"
-  integrity sha512-0WLEifPROw3c7Niqi4S7NhVQ/7ZAGAQ0k4VlAKBWUC3EwegElOZX53Q4zVSOVn0eVGzL6mxJtE958yht2cX3ng==
+"@cumulus/cmr-client@21.2.1":
+  version "21.2.1"
+  resolved "https://registry.yarnpkg.com/@cumulus/cmr-client/-/cmr-client-21.2.1.tgz#a99482287bdc30ef4af56f9e95eb98d20c419708"
+  integrity sha512-FuKFOZd5S7t1PihXDtdpxtU6j7OBNIRuxI9J3f/J+V1indZnbg7XnZXb7eQvmtfMQAVl7AthzvsvFRju6kgnhw==
   dependencies:
-    "@cumulus/aws-client" "21.2.0"
-    "@cumulus/common" "21.2.0"
-    "@cumulus/errors" "21.2.0"
-    "@cumulus/logger" "21.2.0"
+    "@cumulus/aws-client" "21.2.1"
+    "@cumulus/common" "21.2.1"
+    "@cumulus/errors" "21.2.1"
+    "@cumulus/logger" "21.2.1"
     got "^11.8.5"
     jsonwebtoken "^9.0.0"
     lodash "^4.17.21"
@@ -1723,19 +1723,19 @@
     xml2js "0.5.0"
     zod "^3.20.2"
 
-"@cumulus/cmrjs@21.2.0":
-  version "21.2.0"
-  resolved "https://registry.yarnpkg.com/@cumulus/cmrjs/-/cmrjs-21.2.0.tgz#e2e0dfd6732c3d076963a5c7d56e4a3367ea94cb"
-  integrity sha512-egQtDGPbZPbx+sOdTGZJV3vynf8EUOlBRDJnDo5gG4S1obHVU8fhBz/rCLUgqsrTsONQmCElREGofMaEVLcSMA==
+"@cumulus/cmrjs@21.2.1":
+  version "21.2.1"
+  resolved "https://registry.yarnpkg.com/@cumulus/cmrjs/-/cmrjs-21.2.1.tgz#4ced8bebee4a9e3b4c58ef4da935891c0cc9e6fe"
+  integrity sha512-CsLcSB+zo3ZIEqKNTKS0Zr/qnn4GsUAHmynO6aY/QpE5h2p4o8V1sfRx3nQ6PvUXkey8guGzTv+WSYk0K5tiQg==
   dependencies:
-    "@cumulus/aws-client" "21.2.0"
-    "@cumulus/cmr-client" "21.2.0"
-    "@cumulus/common" "21.2.0"
-    "@cumulus/distribution-utils" "21.2.0"
-    "@cumulus/errors" "21.2.0"
-    "@cumulus/launchpad-auth" "21.2.0"
-    "@cumulus/logger" "21.2.0"
-    "@cumulus/message" "21.2.0"
+    "@cumulus/aws-client" "21.2.1"
+    "@cumulus/cmr-client" "21.2.1"
+    "@cumulus/common" "21.2.1"
+    "@cumulus/distribution-utils" "21.2.1"
+    "@cumulus/errors" "21.2.1"
+    "@cumulus/launchpad-auth" "21.2.1"
+    "@cumulus/logger" "21.2.1"
+    "@cumulus/message" "21.2.1"
     got "^11.8.1"
     js2xmlparser "^5.0.0"
     lodash "^4.17.21"
@@ -1743,16 +1743,16 @@
     url-join "^1.0.0"
     xml2js "0.5.0"
 
-"@cumulus/common@21.2.0":
-  version "21.2.0"
-  resolved "https://registry.yarnpkg.com/@cumulus/common/-/common-21.2.0.tgz#a4dceb83e52ec46ef8341340def35e6e1dec4cd5"
-  integrity sha512-eu/IaMjVPQwIn56ZtkiBHfEoqE3gyjeFiJl04g4yEBOvoTxynFAJvqjfGmFp7/3DIDAz0bsHxz4jctWyXeEK8A==
+"@cumulus/common@21.2.1":
+  version "21.2.1"
+  resolved "https://registry.yarnpkg.com/@cumulus/common/-/common-21.2.1.tgz#021fedcec400db5e27161c6d7a4dd268ca655140"
+  integrity sha512-AiKxL7IisJC/n0ItNqfMZQ5QQfj0C09qqM7qc0GZNndZaMMwEgfUWu+0KKpSigjeAiXg1bZi6Iycjheinn671Q==
   dependencies:
     "@aws-sdk/client-s3" "^3.621.0"
     "@aws-sdk/signature-v4-crt" "^3.621.0"
-    "@cumulus/aws-client" "21.2.0"
-    "@cumulus/errors" "21.2.0"
-    "@cumulus/logger" "21.2.0"
+    "@cumulus/aws-client" "21.2.1"
+    "@cumulus/errors" "21.2.1"
+    "@cumulus/logger" "21.2.1"
     ajv "^6.12.3"
     follow-redirects "^1.2.4"
     fs-extra "^5.0.0"
@@ -1768,69 +1768,69 @@
     url-join "^4.0.0"
     uuid "^3.2.1"
 
-"@cumulus/cumulus-message-adapter-js@2.0.4":
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/@cumulus/cumulus-message-adapter-js/-/cumulus-message-adapter-js-2.0.4.tgz#e05b21e7dd5a1d9eff252934d390c67948247221"
-  integrity sha512-v89nPeF/K6AowShdS1YWHtDkSVWvUkytm52bMpb0PSacHeytI/eAuPV16BR/fdBCi6pFko5XHLGjrMrMqZFCOQ==
+"@cumulus/cumulus-message-adapter-js@2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@cumulus/cumulus-message-adapter-js/-/cumulus-message-adapter-js-2.2.0.tgz#042080227621a3e0894134a6bcdbd09fb236351d"
+  integrity sha512-FJ056WO8ciLBcI0q+o8xQ3GR950fK8kgOfE7CDUW0TzV2S7HxeN63IAR2fv8xPxRZfXXzKuO6S/2hzV3GDpBXg==
   dependencies:
     "@cumulus/types" "^9.6.0"
     "@types/aws-lambda" "^8.10.58"
     execa "^4.0.0"
     lookpath "1.0.3"
 
-"@cumulus/distribution-utils@21.2.0":
-  version "21.2.0"
-  resolved "https://registry.yarnpkg.com/@cumulus/distribution-utils/-/distribution-utils-21.2.0.tgz#07d20ade1d5434228ae7679b13b74b17278246d3"
-  integrity sha512-c+C4tUcUvwKcnkXZG1YLophv1Ubg3WSmejO2KSXDIEbIM3MW+iQocr0Gop5IncUYlb0vX2/2i/nOGMjZB7j1dA==
+"@cumulus/distribution-utils@21.2.1":
+  version "21.2.1"
+  resolved "https://registry.yarnpkg.com/@cumulus/distribution-utils/-/distribution-utils-21.2.1.tgz#97088c64b86c70426e637bbe22f440177cb93152"
+  integrity sha512-9wJrhUk2UjHVVxbEHTKkAY/s3b9GeT9ysc9Z4uiPrOJ7ANCoXH1+VHKJx2TqfzSmFrTGzztQZ78hugZ8/gxtpQ==
   dependencies:
-    "@cumulus/aws-client" "21.2.0"
-    "@cumulus/common" "21.2.0"
-    "@cumulus/errors" "21.2.0"
+    "@cumulus/aws-client" "21.2.1"
+    "@cumulus/common" "21.2.1"
+    "@cumulus/errors" "21.2.1"
     url-join "^1.1.0"
 
-"@cumulus/errors@21.2.0":
-  version "21.2.0"
-  resolved "https://registry.yarnpkg.com/@cumulus/errors/-/errors-21.2.0.tgz#a8b9de740fc8cabe928d22cec6daf907613ff1de"
-  integrity sha512-68JPVkfD5ALjyKJIMQYAERnCWD/ITRU5n2flM8V9SW8HTdVEo/2UxOSIhA5vG8E+L6pVzDD+1PlzwbWhrtW1dw==
+"@cumulus/errors@21.2.1":
+  version "21.2.1"
+  resolved "https://registry.yarnpkg.com/@cumulus/errors/-/errors-21.2.1.tgz#f4ef090071f5abdc815b6bd7392282e30d270005"
+  integrity sha512-Lo/KNSkEsQLnix85En2jp4/JWE/X7chpJds324Mf3sWDQOKzfDUx0p/a21ML5b4Ox7WiArtQ+61Zv73upkf1Ig==
   dependencies:
     lodash "~4.17.21"
 
-"@cumulus/launchpad-auth@21.2.0":
-  version "21.2.0"
-  resolved "https://registry.yarnpkg.com/@cumulus/launchpad-auth/-/launchpad-auth-21.2.0.tgz#b830bf5de02e155777f98c10377e3608f48bdce5"
-  integrity sha512-enKDfijuww7+Bg7FfjEFBaxNDd6LSqpGhTVRqI5sFg5eEv6kPX9979k8PU5+pAIwYkCxDSRdAGu2vqYcuNSXJA==
+"@cumulus/launchpad-auth@21.2.1":
+  version "21.2.1"
+  resolved "https://registry.yarnpkg.com/@cumulus/launchpad-auth/-/launchpad-auth-21.2.1.tgz#61e64f3967608fed00c59bb8ebe2c95355714d7e"
+  integrity sha512-W/ogvq/QwbVzn0JcgOpsizlNIeY6RtMDs5651bidQAiAuEKQFNRbtL0E/rPlqZuVhr07b++bo0aPvzYIL83Efw==
   dependencies:
-    "@cumulus/aws-client" "21.2.0"
-    "@cumulus/logger" "21.2.0"
+    "@cumulus/aws-client" "21.2.1"
+    "@cumulus/logger" "21.2.1"
     got "^11.8.5"
     lodash "^4.17.21"
     uuid "^3.2.1"
 
-"@cumulus/logger@21.2.0":
-  version "21.2.0"
-  resolved "https://registry.yarnpkg.com/@cumulus/logger/-/logger-21.2.0.tgz#179f9105a0f23ce9d414c9f5b40ec423c3c7755e"
-  integrity sha512-ZUAqN44SfstBfHO5VttkcO1gemLVQTn+632BrKRAjxEMBPsft9urC7fFaejUF5unmBPZJhXZwbngRk9EfI+ZSA==
+"@cumulus/logger@21.2.1":
+  version "21.2.1"
+  resolved "https://registry.yarnpkg.com/@cumulus/logger/-/logger-21.2.1.tgz#8d685c64cf387547e59c8be461850fa1e33389de"
+  integrity sha512-AqrphcO0jHFGEraAFdAMbN0AYGNzj/wT3EZQiIaPxJ+5h70iUbywM+vrRq+yGheXec8cKXRdbqtanrrVZgd79Q==
   dependencies:
     lodash.iserror "^3.1.1"
 
-"@cumulus/message@21.2.0":
-  version "21.2.0"
-  resolved "https://registry.yarnpkg.com/@cumulus/message/-/message-21.2.0.tgz#11e695061fddc201d8fe53832238f660248a4bab"
-  integrity sha512-W3gkbc4C1NDNJcSqq9/b2yLsszOYOzhgCAP4PtZ44kfdNrGSp4MhodBfNyEDVE0c6X4PlQNGs1VclwRZaAJKEg==
+"@cumulus/message@21.2.1":
+  version "21.2.1"
+  resolved "https://registry.yarnpkg.com/@cumulus/message/-/message-21.2.1.tgz#f1981e884ddaf0eb5db61099fe97e9a4c2a522c3"
+  integrity sha512-0KOdiOCdlt/oC+KZWN+3lT2mkBHPEh7dsf0CPvPIwG7zL3FDqlbRPk3sh8ZW3JxEqT/zht1VmkNalk7yCxONWg==
   dependencies:
-    "@cumulus/aws-client" "21.2.0"
-    "@cumulus/common" "21.2.0"
-    "@cumulus/errors" "21.2.0"
-    "@cumulus/logger" "21.2.0"
-    "@cumulus/types" "21.2.0"
+    "@cumulus/aws-client" "21.2.1"
+    "@cumulus/common" "21.2.1"
+    "@cumulus/errors" "21.2.1"
+    "@cumulus/logger" "21.2.1"
+    "@cumulus/types" "21.2.1"
     jsonpath-plus "^10.0.0"
     lodash "^4.17.21"
     uuidv4 "^6.2.13"
 
-"@cumulus/types@21.2.0":
-  version "21.2.0"
-  resolved "https://registry.yarnpkg.com/@cumulus/types/-/types-21.2.0.tgz#202bff6ca16cc2e45b3460f01cb96d932f5c1f54"
-  integrity sha512-Ox5GTFr+6zQCGw3z3vvRvBx8nTtme1xbekJNSmj7HvZwVkiMtpZ6t4exYS1nvTHM4TBp0JTn3ri25wjExiolFQ==
+"@cumulus/types@21.2.1":
+  version "21.2.1"
+  resolved "https://registry.yarnpkg.com/@cumulus/types/-/types-21.2.1.tgz#89d55818987a2b5a3a993fcc85a6550d69e75a34"
+  integrity sha512-rND+nSdP+x5jHOeul/P9U+vlrYOf16GRpTL1epty2+RA1L1ituH1c+mh004NIyOozqHL3lGLumKGjg6+h3C2MA==
 
 "@cumulus/types@^9.6.0":
   version "9.9.4"
@@ -2560,9 +2560,9 @@
     tslib "^2.6.2"
 
 "@smithy/util-retry@^4.3.6":
-  version "4.3.6"
-  resolved "https://registry.yarnpkg.com/@smithy/util-retry/-/util-retry-4.3.6.tgz#8d242d7e736593ca3f1c0f056279909b881d6e2a"
-  integrity sha512-p6/FO1n2KxMeQyna067i0uJ6TSbb165ZhnRtCpWh4Foxqbfc6oW+XITaL8QkFJj3KFnDe2URt4gOhgU06EP9ew==
+  version "4.3.8"
+  resolved "https://registry.yarnpkg.com/@smithy/util-retry/-/util-retry-4.3.8.tgz#7f904ed8e5bad2b5f2e6aa1e193db2b46b2c57df"
+  integrity sha512-LUIxbTBi+OpvXpg91poGA6BdyoleMDLnfXjVDqyi2RvZmTveY5loE/FgYUBCR5LU2BThW2SoZRh8dTIIy38IPw==
   dependencies:
     "@smithy/service-error-classification" "^4.3.1"
     "@smithy/types" "^4.14.1"
@@ -2878,9 +2878,9 @@
     eslint-visitor-keys "^3.3.0"
 
 "@ungap/structured-clone@^1.2.0":
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/@ungap/structured-clone/-/structured-clone-1.3.0.tgz#d06bbb384ebcf6c505fde1c3d0ed4ddffe0aaff8"
-  integrity sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/@ungap/structured-clone/-/structured-clone-1.3.1.tgz#0e8f34854df7966b09304a18e808b23997bb9fc1"
+  integrity sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==
 
 JSONStream@^1.0.4:
   version "1.3.5"
@@ -3222,12 +3222,12 @@ aws-crt@^1.24.0:
     mqtt "^4.3.8"
     process "^0.11.10"
 
-axios@^1.12.2, axios@^1.8.3:
-  version "1.15.2"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-1.15.2.tgz#eb8fb6d30349abace6ade5b4cb4d9e8a0dc23e5b"
-  integrity sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==
+axios@^1.12.2, axios@^1.13.5:
+  version "1.16.0"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.16.0.tgz#f8e5dd931cef2a5f8c32216d5784eda2f8750eb7"
+  integrity sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==
   dependencies:
-    follow-redirects "^1.15.11"
+    follow-redirects "^1.16.0"
     form-data "^4.0.5"
     proxy-from-env "^2.1.0"
 
@@ -3242,9 +3242,9 @@ base64-js@^1.0.2, base64-js@^1.3.1:
   integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
 
 baseline-browser-mapping@^2.10.12:
-  version "2.10.24"
-  resolved "https://registry.yarnpkg.com/baseline-browser-mapping/-/baseline-browser-mapping-2.10.24.tgz#6dc320c7bf53859ec2bf55d54db6d2e5c078df16"
-  integrity sha512-I2NkZOOrj2XuguvWCK6OVh9GavsNjZjK908Rq3mIBK25+GD8vPX5w2WdxVqnQ7xx3SrZJiCiZFu+/Oz50oSYSA==
+  version "2.10.27"
+  resolved "https://registry.yarnpkg.com/baseline-browser-mapping/-/baseline-browser-mapping-2.10.27.tgz#fee941c2a0b42cdf83c6427e4c830b1d0bdab2c3"
+  integrity sha512-zEs/ufmZoUd7WftKpKyXaT6RFxpQ5Qm9xytKRHvJfxFV9DFJkZph9RvJ1LcOUi0Z1ZVijMte65JbILeV+8QQEA==
 
 big-integer@^1.6.44:
   version "1.6.52"
@@ -3455,9 +3455,9 @@ camelcase@^7.0.0:
   integrity sha512-xlx1yCK2Oc1APsPXDL2LdlNP6+uu8OCDdhOBSVT279M/S+y75O30C2VuD8T2ogdePBBl7PfPF4504tnLgX3zfw==
 
 caniuse-lite@^1.0.30001782:
-  version "1.0.30001791"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001791.tgz#dfb93d85c40ad380c57123e72e10f3c575786b51"
-  integrity sha512-yk0l/YSrOnFZk3UROpDLQD9+kC1l4meK/wed583AXrzoarMGJcbRi2Q4RaUYbKxYAsZ8sWmaSa/DsLmdBeI1vQ==
+  version "1.0.30001792"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001792.tgz#ca8bb9be244835a335e2018272ce7223691873c5"
+  integrity sha512-hVLMUZFgR4JJ6ACt1uEESvQN1/dBVqPAKY0hgrV70eN3391K6juAfTjKZLKvOMsx8PxA7gsY1/tLMMTcfFLLpw==
 
 cbor@^8.1.0:
   version "8.1.0"
@@ -4316,9 +4316,9 @@ ecdsa-sig-formatter@1.0.11:
     safe-buffer "^5.0.1"
 
 electron-to-chromium@^1.5.328:
-  version "1.5.345"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.5.345.tgz#39d8f7cbc19350e5d7d94a471c111eb7326e8ef6"
-  integrity sha512-F9JXQGiMrz6yVNPI2qOVPvB9HzjH5cGzhs8oJ6A28V5L/YnzN/0KsuiibqF+F1Fd9qxFzD1BUnYSd8JfULxTwg==
+  version "1.5.352"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.5.352.tgz#0b57303cf654d7e4353edf01abe1ca55e5136063"
+  integrity sha512-9wHk8x6dyuimoe18EdiDPWKExNdxYqo4fn4FwOVVper6RxT3cmpBwBkWWfSOCYJjQdIco/nPhJhNLmn4Ufg1Yg==
 
 emittery@^1.0.1:
   version "1.2.1"
@@ -4779,9 +4779,9 @@ fast-levenshtein@^2.0.6:
   integrity sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==
 
 fast-uri@^3.0.1:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.1.0.tgz#66eecff6c764c0df9b762e62ca7edcfb53b4edfa"
-  integrity sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.1.2.tgz#8af3d4fc9d3e71b11572cc2673b514a7d1a8c8ec"
+  integrity sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==
 
 fast-url-parser@^1.1.3:
   version "1.1.3"
@@ -4791,9 +4791,9 @@ fast-url-parser@^1.1.3:
     punycode "^1.3.2"
 
 fast-xml-builder@^1.1.5:
-  version "1.1.5"
-  resolved "https://registry.yarnpkg.com/fast-xml-builder/-/fast-xml-builder-1.1.5.tgz#50188e1452a5fa095f415d3e63dcac0a1dbcbf11"
-  integrity sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==
+  version "1.1.9"
+  resolved "https://registry.yarnpkg.com/fast-xml-builder/-/fast-xml-builder-1.1.9.tgz#96bf8de1e3a5f560149b6092844db4e6fd0ee38f"
+  integrity sha512-jcyKVSEX13iseJqg7n/KWw+xnu/7fdrZ333Fac54KjHDIELVCfDDJXYIm6DTJ0Su4gSzrhqiK0DzY/wZbF40mw==
   dependencies:
     path-expression-matcher "^1.1.3"
 
@@ -4936,7 +4936,7 @@ flatted@^3.2.9:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.4.2.tgz#f5c23c107f0f37de8dbdf24f13722b3b98d52726"
   integrity sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==
 
-follow-redirects@^1.15.11, follow-redirects@^1.15.6, follow-redirects@^1.2.4:
+follow-redirects@^1.15.6, follow-redirects@^1.16.0, follow-redirects@^1.2.4:
   version "1.16.0"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.16.0.tgz#28474a159d3b9d11ef62050a14ed60e4df6d61bc"
   integrity sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==
@@ -5346,7 +5346,7 @@ hasha@^5.0.0:
     is-stream "^2.0.0"
     type-fest "^0.8.0"
 
-hasown@^2.0.2:
+hasown@^2.0.2, hasown@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/hasown/-/hasown-2.0.3.tgz#5e5c2b15b60370a4c7930c383dfb76bf17bc403c"
   integrity sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==
@@ -5620,11 +5620,11 @@ is-callable@^1.2.7:
   integrity sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==
 
 is-core-module@^2.16.1, is-core-module@^2.5.0, is-core-module@^2.8.1:
-  version "2.16.1"
-  resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.16.1.tgz#2a98801a849f43e2add644fbb6bc6229b19a4ef4"
-  integrity sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==
+  version "2.16.2"
+  resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.16.2.tgz#3e07450a8080ebce3fbf0cac494f4d2ab324e082"
+  integrity sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==
   dependencies:
-    hasown "^2.0.2"
+    hasown "^2.0.3"
 
 is-data-view@^1.0.1, is-data-view@^1.0.2:
   version "1.0.2"
@@ -8827,9 +8827,9 @@ yallist@^4.0.0:
   integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
 
 yaml@^2.6.1:
-  version "2.8.3"
-  resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.8.3.tgz#a0d6bd2efb3dd03c59370223701834e60409bd7d"
-  integrity sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==
+  version "2.8.4"
+  resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.8.4.tgz#4b5f411dd25f9544914d8673d4da7f29248e5e2e"
+  integrity sha512-ml/JPOj9fOQK8RNnWojA67GbZ0ApXAUlN2UQclwv2eVgTgn7O9gg9o7paZWKMp4g0H3nTLtS9LVzhkpOFIKzog==
 
 yargs-parser@^18.1.2:
   version "18.1.3"


### PR DESCRIPTION
Ran into a difficult problem with lambda sizes.  AWS does not allow Lambdas that are over 250mb, currently many things get bundled into the lambda (that is sort of the nature of node js).  
Solved it by adding some prune methods which trimmed off stuff that is not needed for production build.  Just diagnosing this problem proved to be difficult but it is corrected for now.  Adding comments to the ticket for that. 

#523

