### PR TITLE
Adapted CNM Response workflow for Cumulus Core. #544

### DIFF
--- a/app/stacks/cumulus/templates/cnm-ingest-and-publish-granule-workflow.asl.json
+++ b/app/stacks/cumulus/templates/cnm-ingest-and-publish-granule-workflow.asl.json
@@ -518,13 +518,11 @@
         "cma": {
           "event.$": "$",
           "task_config": {
-            "OriginalCNM": "{$.meta.cnm}",
+            "cnm": "{$.meta.cnm}",
             "distribution_endpoint": "{$.meta.distribution_endpoint}",
-            "CNMResponseStream": "{$.meta.cnmResponseStream}",
-            "response-endpoint": "{$.meta.cnmResponseStream}",
-            "region": "us-west-2",
+            "exception":"{$.exception}",
             "type": "{$.meta.cnmResponseMethod}",
-            "WorkflowException": "{$.exception}",
+            "responseArns": ["{$.meta.cnmResponseStream}"],
             "cumulus_message": {
               "outputs": [
                 {
@@ -536,7 +534,7 @@
                   "destination": "{$.meta.cnmResponse}"
                 },
                 {
-                  "source": "{$.input.input}",
+                  "source": "{$}",
                   "destination": "{$.payload}"
                 }
               ]
@@ -587,11 +585,11 @@
         "cma": {
           "event.$": "$",
           "task_config": {
-            "OriginalCNM": "{$.meta.cnm}",
-            "response-endpoint": "{$.meta.cnmResponseStream}",
-            "region": "us-west-2",
+            "cnm": "{$.meta.cnm}",
+            "distribution_endpoint": "{$.meta.distribution_endpoint}",
+            "exception":"{$.exception}",
             "type": "{$.meta.cnmResponseMethod}",
-            "WorkflowException": "{$.exception}",
+            "responseArns": ["{$.meta.cnmResponseStream}"],
             "cumulus_message": {
               "outputs": [
                 {
@@ -599,7 +597,7 @@
                   "destination": "{$.meta.cnmResponse}"
                 },
                 {
-                  "source": "{$.input.input}",
+                  "source": "{$}",
                   "destination": "{$.payload}"
                 }
               ]


### PR DESCRIPTION
Adapted CNM Response workflow for Cumulus Core. #544

In version 21.3.2, Cumulus added the CNM Response to the core.
This made some of the parameters change which effects the workflow template.
That has now been adjusted/fixed.

Tested and works on Sandbox, need to push to UAT and PROD (and test there as well).

#544