### PR TITLE
Iss 547  data management items umbra sidd and sicd

### DIFF
--- a/app/stacks/cumulus/resources/collections/Umbra_SICD___1.json
+++ b/app/stacks/cumulus/resources/collections/Umbra_SICD___1.json
@@ -3,12 +3,14 @@
   "version": "1",
   "duplicateHandling": "replace",
   "granuleId": ".*",
-  "granuleIdExtraction": "^(\\d{4}-\\d{2}-\\d{2}-\\d{2}-\\d{2}-\\d{2}_[A-Z]+-\\d{2}.+)$",
+  "granuleIdExtraction": "^(\\d{4}-\\d{2}-\\d{2}-\\d{2}-\\d{2}-\\d{2}_[A-Z]+-\\d{2}).+$",
   "sampleFileName": "2025-10-04-06-21-14_UMBRA-08_SICD_MM.nitf",
   "ignoreFilesConfigForDiscovery": false,
-  "url_path": "{cmrMetadata.CollectionReference.ShortName}___{cmrMetadata.CollectionReference.Version}/{dateFormat(cmrMetadata.TemporalExtent.SingleDateTime, YYYY)}/{dateFormat(cmrMetadata.TemporalExtent.SingleDateTime, MM)}/{dateFormat(cmrMetadata.TemporalExtent.SingleDateTime, DD)}/{cmrMetadata.GranuleUR}",
+  "url_path": "{cmrMetadata.CollectionReference.ShortName}___{cmrMetadata.CollectionReference.Version}/{dateFormat(cmrMetadata.TemporalExtent.RangeDateTime.BeginningDateTime, YYYY)}/{dateFormat(cmrMetadata.TemporalExtent.RangeDateTime.BeginningDateTime, MM)}/{dateFormat(cmrMetadata.TemporalExtent.RangeDateTime.BeginningDateTime, DD)}/{cmrMetadata.GranuleUR}",
   "meta": {
-    "preferredQueueBatchSize": 1
+    "preferredQueueBatchSize": 1,
+    "prefixGranuleIds": true,
+    "granuleRecoveryWorkflow": "OrcaRecoveryWorkflow"
   },
   "files": [
   	{

--- a/app/stacks/cumulus/resources/collections/Umbra_SICD___1.json
+++ b/app/stacks/cumulus/resources/collections/Umbra_SICD___1.json
@@ -1,0 +1,33 @@
+{
+  "name": "Umbra_SICD",
+  "version": "1",
+  "duplicateHandling": "replace",
+  "granuleId": ".*",
+  "granuleIdExtraction": "^(\\d{4}-\\d{2}-\\d{2}-\\d{2}-\\d{2}-\\d{2}_[A-Z]+-\\d{2}.+)$",
+  "sampleFileName": "2025-10-04-06-21-14_UMBRA-08_SICD_MM.nitf",
+  "ignoreFilesConfigForDiscovery": false,
+  "url_path": "{cmrMetadata.CollectionReference.ShortName}___{cmrMetadata.CollectionReference.Version}/{dateFormat(cmrMetadata.TemporalExtent.SingleDateTime, YYYY)}/{dateFormat(cmrMetadata.TemporalExtent.SingleDateTime, MM)}/{dateFormat(cmrMetadata.TemporalExtent.SingleDateTime, DD)}/{cmrMetadata.GranuleUR}",
+  "meta": {
+    "preferredQueueBatchSize": 1
+  },
+  "files": [
+  	{
+      "regex": ".*-cmr[.]json$",
+      "sampleFileName": "2025-10-04-06-21-14_UMBRA-08_SICD-cmr.json",
+      "type": "metadata",
+      "bucket": "protected"
+    },
+    {
+      "regex": ".*_MM[.]nitf$",
+      "sampleFileName": "2025-10-04-06-21-14_UMBRA-08_SICD_MM.nitf",
+      "type": "data",
+      "bucket": "protected"
+    },
+    {
+      "regex": ".*[.]stac[.]v2[.]json$",
+      "sampleFileName": "2025-10-04-06-21-14_UMBRA-08.stac.v2.json",
+      "type": "data",
+      "bucket": "protected"
+    }
+  ]
+}

--- a/app/stacks/cumulus/resources/collections/Umbra_SIDD___1.json
+++ b/app/stacks/cumulus/resources/collections/Umbra_SIDD___1.json
@@ -1,0 +1,33 @@
+{
+  "name": "Umbra_SIDD",
+  "version": "1",
+  "duplicateHandling": "replace",
+  "granuleId": ".*",
+  "granuleIdExtraction": "^(\\d{4}-\\d{2}-\\d{2}-\\d{2}-\\d{2}-\\d{2}_[A-Z]+-\\d{2}.+)$",
+  "sampleFileName": "2025-10-04-06-21-14_UMBRA-08_SIDD_MM.nitf",
+  "ignoreFilesConfigForDiscovery": false,
+  "url_path": "{cmrMetadata.CollectionReference.ShortName}___{cmrMetadata.CollectionReference.Version}/{dateFormat(cmrMetadata.TemporalExtent.SingleDateTime, YYYY)}/{dateFormat(cmrMetadata.TemporalExtent.SingleDateTime, MM)}/{dateFormat(cmrMetadata.TemporalExtent.SingleDateTime, DD)}/{cmrMetadata.GranuleUR}",
+  "meta": {
+    "preferredQueueBatchSize": 1
+  },
+  "files": [
+  	{
+      "regex": ".*-cmr[.]json$",
+      "sampleFileName": "2025-10-04-06-21-14_UMBRA-08_SIDD-cmr.json",
+      "type": "metadata",
+      "bucket": "protected"
+    },
+    {
+      "regex": ".*_MM[.]nitf$",
+      "sampleFileName": "2025-10-04-06-21-14_UMBRA-08_SIDD_MM.nitf",
+      "type": "data",
+      "bucket": "protected"
+    },
+    {
+      "regex": ".*[.]stac[.]v2[.]json$",
+      "sampleFileName": "2025-10-04-06-21-14_UMBRA-08.stac.v2.json",
+      "type": "data",
+      "bucket": "protected"
+    }
+  ]
+}

--- a/app/stacks/cumulus/resources/collections/Umbra_SIDD___1.json
+++ b/app/stacks/cumulus/resources/collections/Umbra_SIDD___1.json
@@ -3,12 +3,14 @@
   "version": "1",
   "duplicateHandling": "replace",
   "granuleId": ".*",
-  "granuleIdExtraction": "^(\\d{4}-\\d{2}-\\d{2}-\\d{2}-\\d{2}-\\d{2}_[A-Z]+-\\d{2}.+)$",
+  "granuleIdExtraction": "^(\\d{4}-\\d{2}-\\d{2}-\\d{2}-\\d{2}-\\d{2}_[A-Z]+-\\d{2}).+$",
   "sampleFileName": "2025-10-04-06-21-14_UMBRA-08_SIDD_MM.nitf",
   "ignoreFilesConfigForDiscovery": false,
-  "url_path": "{cmrMetadata.CollectionReference.ShortName}___{cmrMetadata.CollectionReference.Version}/{dateFormat(cmrMetadata.TemporalExtent.SingleDateTime, YYYY)}/{dateFormat(cmrMetadata.TemporalExtent.SingleDateTime, MM)}/{dateFormat(cmrMetadata.TemporalExtent.SingleDateTime, DD)}/{cmrMetadata.GranuleUR}",
+  "url_path": "{cmrMetadata.CollectionReference.ShortName}___{cmrMetadata.CollectionReference.Version}/{dateFormat(cmrMetadata.TemporalExtent.RangeDateTime.BeginningDateTime, YYYY)}/{dateFormat(cmrMetadata.TemporalExtent.RangeDateTime.BeginningDateTime, MM)}/{dateFormat(cmrMetadata.TemporalExtent.RangeDateTime.BeginningDateTime, DD)}/{cmrMetadata.GranuleUR}",
   "meta": {
-    "preferredQueueBatchSize": 1
+    "preferredQueueBatchSize": 1,
+    "prefixGranuleIds": true,
+    "granuleRecoveryWorkflow": "OrcaRecoveryWorkflow"
   },
   "files": [
   	{

--- a/app/stacks/cumulus/resources/granules/storage-ss-ingest-prod-ingesteddata-uswest2/umbra/2025/10/04/SICD/2025-10-04-06-21-14_UMBRA-08_SICD/2025-10-04-06-21-14_UMBRA-08.stac.v2.json
+++ b/app/stacks/cumulus/resources/granules/storage-ss-ingest-prod-ingesteddata-uswest2/umbra/2025/10/04/SICD/2025-10-04-06-21-14_UMBRA-08_SICD/2025-10-04-06-21-14_UMBRA-08.stac.v2.json
@@ -1,0 +1,1 @@
+Hello Cumulus!

--- a/app/stacks/cumulus/resources/granules/storage-ss-ingest-prod-ingesteddata-uswest2/umbra/2025/10/04/SICD/2025-10-04-06-21-14_UMBRA-08_SICD/2025-10-04-06-21-14_UMBRA-08_SICD-cmr.json
+++ b/app/stacks/cumulus/resources/granules/storage-ss-ingest-prod-ingesteddata-uswest2/umbra/2025/10/04/SICD/2025-10-04-06-21-14_UMBRA-08_SICD/2025-10-04-06-21-14_UMBRA-08_SICD-cmr.json
@@ -11,7 +11,7 @@
         }
     ],
     "CollectionReference": {
-        "ShortName": "Umbra_sicd",
+        "ShortName": "Umbra_SICD",
         "Version": "1"
     },
     "AccessConstraints": {

--- a/app/stacks/cumulus/resources/granules/storage-ss-ingest-prod-ingesteddata-uswest2/umbra/2025/10/04/SICD/2025-10-04-06-21-14_UMBRA-08_SICD/2025-10-04-06-21-14_UMBRA-08_SICD-cmr.json
+++ b/app/stacks/cumulus/resources/granules/storage-ss-ingest-prod-ingesteddata-uswest2/umbra/2025/10/04/SICD/2025-10-04-06-21-14_UMBRA-08_SICD/2025-10-04-06-21-14_UMBRA-08_SICD-cmr.json
@@ -1,0 +1,121 @@
+{
+    "GranuleUR": "2025-10-04-06-21-14_UMBRA-08_SICD",
+    "ProviderDates": [
+        {
+            "Date": "2026-06-12T18:51:58.187575Z",
+            "Type": "Insert"
+        },
+        {
+            "Date": "2026-06-12T18:51:58.187575Z",
+            "Type": "Update"
+        }
+    ],
+    "CollectionReference": {
+        "ShortName": "Umbra_sicd",
+        "Version": "1"
+    },
+    "AccessConstraints": {
+        "Description": "Access restricted to users approved by CSDA Program",
+        "Value": 1.0
+    },
+    "DataGranule": {
+        "ArchiveAndDistributionInformation": [
+            {
+                "Name": "2025-10-04-06-21-14_UMBRA-08_SICD_MM.nitf",
+                "SizeInBytes": 2371873981,
+                "MimeType": "Not provided",
+                "Checksum": {
+                    "Value": "d5011048fc6127f5c96da93c8886fd0bdbd67f",
+                    "Algorithm": "MD5"
+                }
+            },
+            {
+                "Name": "2025-10-04-06-21-14_UMBRA-08.stac.v2.json",
+                "SizeInBytes": 7772,
+                "MimeType": "application/json",
+                "Checksum": {
+                    "Value": "d50110a8188091293f39109412e2bf9d4d63f8",
+                    "Algorithm": "MD5"
+                }
+            }
+        ],
+        "DayNightFlag": "Day",
+        "ProductionDateTime": "2025-10-04T06:21:15Z"
+    },
+    "TemporalExtent": {
+        "RangeDateTime": {
+            "BeginningDateTime": "2025-10-04T06:21:15Z",
+            "EndingDateTime": "2025-10-04T06:21:18.000001Z"
+        }
+    },
+    "SpatialExtent": {
+        "HorizontalSpatialDomain": {
+            "Geometry": {
+                "GPolygons": [
+                    {
+                        "Boundary": {
+                            "Points": [
+                                {
+                                    "Longitude": -118.06242397745638,
+                                    "Latitude": 34.77219185104929
+                                },
+                                {
+                                    "Longitude": -118.02999646566643,
+                                    "Latitude": 34.808462119652724
+                                },
+                                {
+                                    "Longitude": -118.07398019819311,
+                                    "Latitude": 34.83521188076999
+                                },
+                                {
+                                    "Longitude": -118.10639891451474,
+                                    "Latitude": 34.798930055029125
+                                },
+                                {
+                                    "Longitude": -118.06242397745638,
+                                    "Latitude": 34.77219185104929
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        }
+    },
+    "Platforms": [
+        {
+            "ShortName": "Umbra SAR Constellation",
+            "Instruments": [
+                {
+                    "ShortName": "Umbra X-SAR"
+                }
+            ]
+        }
+    ],
+    "Projects": [
+        {
+            "ShortName": "CSDA"
+        }
+    ],
+    "RelatedUrls": [
+        {
+            "URL": "s3://ss-ingest-staging-ingesteddatac45dd6b6-3xhhk78ir4sw/storage/umbra/2025/10/04/SICD/2025-10-04-06-21-14_UMBRA-08_SICD/2025-10-04-06-21-14_UMBRA-08_SICD_MM.nitf",
+            "Type": "GET DATA VIA DIRECT ACCESS",
+            "Description": "Imagery in NITF 2.1 Commercial Dataset Requirements Document (NCDRD) format or NITF21NCDRD format",
+            "Format": "NITF21NCDRD",
+            "MimeType": "Not provided"
+        },
+        {
+            "URL": "s3://ss-ingest-staging-ingesteddatac45dd6b6-3xhhk78ir4sw/storage/umbra/2025/10/04/SICD/2025-10-04-06-21-14_UMBRA-08_SICD/2025-10-04-06-21-14_UMBRA-08.stac.v2.json",
+            "Type": "EXTENDED METADATA",
+            "Description": "STAC metadata file",
+            "Format": "JSON",
+            "MimeType": "application/json"
+        }
+    ],
+    "MetadataSpecification": {
+        "URL": "https://cdn.earthdata.nasa.gov/umm/granule/v1.6.6",
+        "Name": "UMM-G",
+        "Version": "1.6.6"
+    }
+}

--- a/app/stacks/cumulus/resources/granules/storage-ss-ingest-prod-ingesteddata-uswest2/umbra/2025/10/04/SICD/2025-10-04-06-21-14_UMBRA-08_SICD/2025-10-04-06-21-14_UMBRA-08_SICD_MM.nitf
+++ b/app/stacks/cumulus/resources/granules/storage-ss-ingest-prod-ingesteddata-uswest2/umbra/2025/10/04/SICD/2025-10-04-06-21-14_UMBRA-08_SICD/2025-10-04-06-21-14_UMBRA-08_SICD_MM.nitf
@@ -1,0 +1,1 @@
+Hello Cumulus!

--- a/app/stacks/cumulus/resources/granules/storage-ss-ingest-prod-ingesteddata-uswest2/umbra/2025/10/04/SIDD/2025-10-04-06-21-14_UMBRA-08_SIDD/2025-10-04-06-21-14_UMBRA-08.stac.v2.json
+++ b/app/stacks/cumulus/resources/granules/storage-ss-ingest-prod-ingesteddata-uswest2/umbra/2025/10/04/SIDD/2025-10-04-06-21-14_UMBRA-08_SIDD/2025-10-04-06-21-14_UMBRA-08.stac.v2.json
@@ -1,0 +1,1 @@
+Hello Cumulus!

--- a/app/stacks/cumulus/resources/granules/storage-ss-ingest-prod-ingesteddata-uswest2/umbra/2025/10/04/SIDD/2025-10-04-06-21-14_UMBRA-08_SIDD/2025-10-04-06-21-14_UMBRA-08_SIDD-cmr.json
+++ b/app/stacks/cumulus/resources/granules/storage-ss-ingest-prod-ingesteddata-uswest2/umbra/2025/10/04/SIDD/2025-10-04-06-21-14_UMBRA-08_SIDD/2025-10-04-06-21-14_UMBRA-08_SIDD-cmr.json
@@ -1,0 +1,121 @@
+{
+    "GranuleUR": "2025-10-04-06-21-14_UMBRA-08_SIDD",
+    "ProviderDates": [
+        {
+            "Date": "2026-06-16T16:34:20.102949Z",
+            "Type": "Insert"
+        },
+        {
+            "Date": "2026-06-16T16:34:20.102949Z",
+            "Type": "Update"
+        }
+    ],
+    "CollectionReference": {
+        "ShortName": "Umbra_sidd",
+        "Version": "1"
+    },
+    "AccessConstraints": {
+        "Description": "Access restricted to users approved by CSDA Program",
+        "Value": 1.0
+    },
+    "DataGranule": {
+        "ArchiveAndDistributionInformation": [
+            {
+                "Name": "2025-10-04-06-21-14_UMBRA-08_SIDD_MM.nitf",
+                "SizeInBytes": 512074671,
+                "MimeType": "Not provided",
+                "Checksum": {
+                    "Value": "d50110b056c7d358330d35e2ecb9e2660a2a51",
+                    "Algorithm": "MD5"
+                }
+            },
+            {
+                "Name": "2025-10-04-06-21-14_UMBRA-08.stac.v2.json",
+                "SizeInBytes": 7772,
+                "MimeType": "application/json",
+                "Checksum": {
+                    "Value": "d50110a8188091293f39109412e2bf9d4d63f8",
+                    "Algorithm": "MD5"
+                }
+            }
+        ],
+        "DayNightFlag": "Day",
+        "ProductionDateTime": "2025-10-04T06:21:15Z"
+    },
+    "TemporalExtent": {
+        "RangeDateTime": {
+            "BeginningDateTime": "2025-10-04T06:21:15Z",
+            "EndingDateTime": "2025-10-04T06:21:18.000001Z"
+        }
+    },
+    "SpatialExtent": {
+        "HorizontalSpatialDomain": {
+            "Geometry": {
+                "GPolygons": [
+                    {
+                        "Boundary": {
+                            "Points": [
+                                {
+                                    "Longitude": -118.06242397745638,
+                                    "Latitude": 34.77219185104929
+                                },
+                                {
+                                    "Longitude": -118.02999646566643,
+                                    "Latitude": 34.808462119652724
+                                },
+                                {
+                                    "Longitude": -118.07398019819311,
+                                    "Latitude": 34.83521188076999
+                                },
+                                {
+                                    "Longitude": -118.10639891451474,
+                                    "Latitude": 34.798930055029125
+                                },
+                                {
+                                    "Longitude": -118.06242397745638,
+                                    "Latitude": 34.77219185104929
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        }
+    },
+    "Platforms": [
+        {
+            "ShortName": "Umbra SAR Constellation",
+            "Instruments": [
+                {
+                    "ShortName": "Umbra X-SAR"
+                }
+            ]
+        }
+    ],
+    "Projects": [
+        {
+            "ShortName": "CSDA"
+        }
+    ],
+    "RelatedUrls": [
+        {
+            "URL": "s3://ss-ingest-staging-ingesteddatac45dd6b6-3xhhk78ir4sw/storage/umbra/2025/10/04/SIDD/2025-10-04-06-21-14_UMBRA-08_SIDD/2025-10-04-06-21-14_UMBRA-08_SIDD_MM.nitf",
+            "Type": "GET DATA VIA DIRECT ACCESS",
+            "Description": "Imagery in NITF 2.1 Commercial Dataset Requirements Document (NCDRD) format or NITF21NCDRD format",
+            "Format": "NITF21NCDRD",
+            "MimeType": "Not provided"
+        },
+        {
+            "URL": "s3://ss-ingest-staging-ingesteddatac45dd6b6-3xhhk78ir4sw/storage/umbra/2025/10/04/SIDD/2025-10-04-06-21-14_UMBRA-08_SIDD/2025-10-04-06-21-14_UMBRA-08.stac.v2.json",
+            "Type": "EXTENDED METADATA",
+            "Description": "STAC metadata file",
+            "Format": "JSON",
+            "MimeType": "application/json"
+        }
+    ],
+    "MetadataSpecification": {
+        "URL": "https://cdn.earthdata.nasa.gov/umm/granule/v1.6.6",
+        "Name": "UMM-G",
+        "Version": "1.6.6"
+    }
+}

--- a/app/stacks/cumulus/resources/granules/storage-ss-ingest-prod-ingesteddata-uswest2/umbra/2025/10/04/SIDD/2025-10-04-06-21-14_UMBRA-08_SIDD/2025-10-04-06-21-14_UMBRA-08_SIDD-cmr.json
+++ b/app/stacks/cumulus/resources/granules/storage-ss-ingest-prod-ingesteddata-uswest2/umbra/2025/10/04/SIDD/2025-10-04-06-21-14_UMBRA-08_SIDD/2025-10-04-06-21-14_UMBRA-08_SIDD-cmr.json
@@ -11,7 +11,7 @@
         }
     ],
     "CollectionReference": {
-        "ShortName": "Umbra_sidd",
+        "ShortName": "Umbra_SIDD",
         "Version": "1"
     },
     "AccessConstraints": {

--- a/app/stacks/cumulus/resources/granules/storage-ss-ingest-prod-ingesteddata-uswest2/umbra/2025/10/04/SIDD/2025-10-04-06-21-14_UMBRA-08_SIDD/2025-10-04-06-21-14_UMBRA-08_SIDD_MM.nitf
+++ b/app/stacks/cumulus/resources/granules/storage-ss-ingest-prod-ingesteddata-uswest2/umbra/2025/10/04/SIDD/2025-10-04-06-21-14_UMBRA-08_SIDD/2025-10-04-06-21-14_UMBRA-08_SIDD_MM.nitf
@@ -1,0 +1,1 @@
+Hello Cumulus!

--- a/app/stacks/cumulus/resources/providers/umbra.json
+++ b/app/stacks/cumulus/resources/providers/umbra.json
@@ -1,0 +1,1 @@
+{"id": "umbra","protocol": "s3","host": "ss-ingest-prod-ingesteddata-uswest2"}

--- a/app/stacks/cumulus/resources/providers/umbra.json
+++ b/app/stacks/cumulus/resources/providers/umbra.json
@@ -1,1 +1,5 @@
-{"id": "umbra","protocol": "s3","host": "ss-ingest-prod-ingesteddata-uswest2"}
+{
+  "id": "umbra",
+  "protocol": "s3",
+  "host": "ss-ingest-prod-ingesteddata-uswest2"
+}

--- a/app/stacks/cumulus/resources/rules/Umbra_SICD/v1/Umbra_SICD___1.json
+++ b/app/stacks/cumulus/resources/rules/Umbra_SICD/v1/Umbra_SICD___1.json
@@ -1,0 +1,21 @@
+{
+  "name": "Umbra_SICD___1",
+  "state": "DISABLED",
+  "rule": {
+    "type": "onetime"
+  },
+  "provider": "umbra",
+  "collection": {
+    "name": "Umbra_SICD",
+    "version": "1"
+  },
+  "workflow": "DiscoverAndQueueGranules",
+  "meta": {
+    "discoverOnly": false,
+    "providerPathFormat": "'storage-ss-ingest-prod-ingesteddata-uswest2/umbra/'yyyy'/'MM'/'dd'/SICD'",
+    "ingestedPathFormat": "'Umbra_SICD___1/'yyyy/MM/dd",
+    "startDate": "2023-01-01T00:00:00Z",
+    "endDate": "2027-01-01T00:00:00Z",
+    "step": "P1D"
+  }
+}

--- a/app/stacks/cumulus/resources/rules/Umbra_SICD/v1/Umbra_SICD___1_SmokeTest.json
+++ b/app/stacks/cumulus/resources/rules/Umbra_SICD/v1/Umbra_SICD___1_SmokeTest.json
@@ -4,14 +4,14 @@
   "rule": {
     "type": "onetime"
   },
-  "provider": "umbra",
+  "provider": "planet",
   "collection": {
     "name": "Umbra_SICD",
     "version": "1"
   },
   "workflow": "DiscoverAndQueueGranules",
   "meta": {
-    "discoverOnly": false,
+  	"discoverOnly": false,
     "providerPathFormat": "'storage-ss-ingest-prod-ingesteddata-uswest2/umbra/'yyyy'/'MM'/'dd'/SICD'",
     "ingestedPathFormat": "'Umbra_SICD___1/'yyyy/MM/dd",
     "startDate": "2025-10-03T00:00:00Z",

--- a/app/stacks/cumulus/resources/rules/Umbra_SICD/v1/Umbra_SICD___1_SmokeTest.json
+++ b/app/stacks/cumulus/resources/rules/Umbra_SICD/v1/Umbra_SICD___1_SmokeTest.json
@@ -1,0 +1,21 @@
+{
+  "name": "Umbra_SICD___1_SmokeTest",
+  "state": "DISABLED",
+  "rule": {
+    "type": "onetime"
+  },
+  "provider": "umbra",
+  "collection": {
+    "name": "Umbra_SICD",
+    "version": "1"
+  },
+  "workflow": "DiscoverAndQueueGranules",
+  "meta": {
+    "discoverOnly": false,
+    "providerPathFormat": "'storage-ss-ingest-prod-ingesteddata-uswest2/umbra/'yyyy'/'MM'/'dd'/SICD'",
+    "ingestedPathFormat": "'Umbra_SICD___1/'yyyy/MM/dd",
+    "startDate": "2025-10-03T00:00:00Z",
+    "endDate": "2025-10-05T00:00:00Z",
+    "step": "P1D"
+  }
+}

--- a/app/stacks/cumulus/resources/rules/Umbra_SICD/v1/Umbra_SICD___1_UAT.json
+++ b/app/stacks/cumulus/resources/rules/Umbra_SICD/v1/Umbra_SICD___1_UAT.json
@@ -1,0 +1,21 @@
+{
+  "name": "Umbra_SICD___1_UAT",
+  "state": "DISABLED",
+  "rule": {
+    "type": "onetime"
+  },
+  "provider": "umbra",
+  "collection": {
+    "name": "Umbra_SICD",
+    "version": "1"
+  },
+  "workflow": "DiscoverAndQueueGranules",
+  "meta": {
+    "discoverOnly": false,
+    "providerPathFormat": "'storage-ss-ingest-prod-ingesteddata-uswest2/umbra/'yyyy'/'MM'/'dd'/SICD'",
+    "ingestedPathFormat": "'Umbra_SICD___1/'yyyy/MM/dd",
+    "startDate": "2025-10-03T00:00:00Z",
+    "endDate": "2025-10-05T00:00:00Z",
+    "step": "P1D"
+  }
+}

--- a/app/stacks/cumulus/resources/rules/Umbra_SIDD/v1/Umbra_SIDD___1.json
+++ b/app/stacks/cumulus/resources/rules/Umbra_SIDD/v1/Umbra_SIDD___1.json
@@ -1,0 +1,21 @@
+{
+  "name": "Umbra_SIDD___1",
+  "state": "DISABLED",
+  "rule": {
+    "type": "onetime"
+  },
+  "provider": "umbra",
+  "collection": {
+    "name": "Umbra_SIDD",
+    "version": "1"
+  },
+  "workflow": "DiscoverAndQueueGranules",
+  "meta": {
+    "discoverOnly": false,
+    "providerPathFormat": "'storage-ss-ingest-prod-ingesteddata-uswest2/umbra/'yyyy'/'MM'/'dd'/SIDD'",
+    "ingestedPathFormat": "'Umbra_SIDD___1/'yyyy/MM/dd",
+    "startDate": "2023-01-01T00:00:00Z",
+    "endDate": "2027-01-01T00:00:00Z",
+    "step": "P1D"
+  }
+}

--- a/app/stacks/cumulus/resources/rules/Umbra_SIDD/v1/Umbra_SIDD___1_SmokeTest.json
+++ b/app/stacks/cumulus/resources/rules/Umbra_SIDD/v1/Umbra_SIDD___1_SmokeTest.json
@@ -4,7 +4,7 @@
   "rule": {
     "type": "onetime"
   },
-  "provider": "umbra",
+  "provider": "planet",
   "collection": {
     "name": "Umbra_SIDD",
     "version": "1"

--- a/app/stacks/cumulus/resources/rules/Umbra_SIDD/v1/Umbra_SIDD___1_SmokeTest.json
+++ b/app/stacks/cumulus/resources/rules/Umbra_SIDD/v1/Umbra_SIDD___1_SmokeTest.json
@@ -1,0 +1,21 @@
+{
+  "name": "Umbra_SIDD___1_SmokeTest",
+  "state": "DISABLED",
+  "rule": {
+    "type": "onetime"
+  },
+  "provider": "umbra",
+  "collection": {
+    "name": "Umbra_SIDD",
+    "version": "1"
+  },
+  "workflow": "DiscoverAndQueueGranules",
+  "meta": {
+    "discoverOnly": false,
+    "providerPathFormat": "'storage-ss-ingest-prod-ingesteddata-uswest2/umbra/'yyyy'/'MM'/'dd'/SIDD'",
+    "ingestedPathFormat": "'Umbra_SIDD___1/'yyyy/MM/dd",
+    "startDate": "2025-10-03T00:00:00Z",
+    "endDate": "2025-10-05T00:00:00Z",
+    "step": "P1D"
+  }
+}

--- a/app/stacks/cumulus/resources/rules/Umbra_SIDD/v1/Umbra_SIDD___1_UAT.json
+++ b/app/stacks/cumulus/resources/rules/Umbra_SIDD/v1/Umbra_SIDD___1_UAT.json
@@ -1,0 +1,21 @@
+{
+  "name": "Umbra_SIDD___1_UAT",
+  "state": "DISABLED",
+  "rule": {
+    "type": "onetime"
+  },
+  "provider": "umbra",
+  "collection": {
+    "name": "Umbra_SIDD",
+    "version": "1"
+  },
+  "workflow": "DiscoverAndQueueGranules",
+  "meta": {
+    "discoverOnly": false,
+    "providerPathFormat": "'storage-ss-ingest-prod-ingesteddata-uswest2/umbra/'yyyy'/'MM'/'dd'/SIDD'",
+    "ingestedPathFormat": "'Umbra_SIDD___1/'yyyy/MM/dd",
+    "startDate": "2025-10-03T00:00:00Z",
+    "endDate": "2025-10-05T00:00:00Z",
+    "step": "P1D"
+  }
+}


### PR DESCRIPTION
Data Management Items for UMBRA SICD and UMBRA SIDD are completed and tested in UAT.
Rules still need to be loaded in PROD when ready to proceed with the ingest.

#547 